### PR TITLE
fix: dry-run pull crashes on uncreatable models dir + redact LAN host (greens CI)

### DIFF
--- a/sndr/compat/models/pull.py
+++ b/sndr/compat/models/pull.py
@@ -73,9 +73,23 @@ def _resolve_models_dir(override: str | None = None) -> Path:
 
 
 def _check_disk_space(target_dir: Path, needed_gb: float, headroom: float = 1.2) -> tuple[bool, str]:
-    """Verify the target dir has enough free space (with `headroom` factor)."""
-    target_dir.mkdir(parents=True, exist_ok=True)
-    stat = shutil.disk_usage(target_dir)
+    """Verify the target dir has enough free space (with `headroom` factor).
+
+    Creating the target can fail — an unwritable root such as `/data`, a
+    read-only mount, or a sandboxed CI runner all raise ``OSError`` from
+    ``mkdir``. That is a *failed check*, not a crash: a ``--dry-run`` must
+    still reach the fit verdict, and a real pull must exit cleanly with the
+    reason rather than dumping a traceback. So treat an uncreatable /
+    unstattable target as "disk check failed" and report why.
+    """
+    try:
+        target_dir.mkdir(parents=True, exist_ok=True)
+    except OSError as e:
+        return False, f"cannot create models dir {target_dir}: {e}"
+    try:
+        stat = shutil.disk_usage(target_dir)
+    except OSError as e:
+        return False, f"cannot check disk at {target_dir}: {e}"
     free_gb = stat.free / 1e9
     need_with_headroom = needed_gb * headroom
     if free_gb < need_with_headroom:

--- a/sndr/model_configs/host.py
+++ b/sndr/model_configs/host.py
@@ -132,6 +132,22 @@ _DEFAULT_PLUGIN_SRC_CANDIDATES = [
 ]
 
 
+def _is_dir_safe(path: Path) -> bool:
+    """Probe-safe ``is_dir()`` — treat an inaccessible candidate as "not a
+    usable directory" instead of crashing the whole detection pass.
+
+    ``pathlib.Path.is_dir()`` returns False for a missing path or broken
+    symlink but PROPAGATES other ``OSError``s — notably ``PermissionError``
+    when a candidate such as ``/data`` exists yet is stat-denied on a
+    sandboxed runner (the 2026-06-29 CI failure). Path detection probes a list
+    of best-guess locations, so an unreadable one must be skipped, not fatal.
+    """
+    try:
+        return path.is_dir()
+    except OSError:
+        return False
+
+
 # Operator-facing env knobs that pre-empt directory probing. When set
 # and pointing at an existing absolute path, the value wins regardless
 # of the auto-detection order. The aliases keep v7.x deployments
@@ -165,7 +181,7 @@ def _env_lookup(var: str) -> Optional[str]:
         if not raw:
             continue
         path = Path(raw).expanduser()
-        if path.is_absolute() and path.is_dir():
+        if path.is_absolute() and _is_dir_safe(path):
             return str(path)
     return None
 
@@ -210,7 +226,7 @@ def detect_paths(
     else:
         cands = models_candidates if models_candidates is not None else _DEFAULT_MODELS_CANDIDATES
         for c in cands:
-            if Path(c).is_dir():
+            if _is_dir_safe(Path(c)):
                 out["models_dir"] = c
                 break
 
@@ -222,7 +238,7 @@ def detect_paths(
         if hf_cache_candidates is None:
             hf_cache_candidates = [str(Path.home() / ".cache" / "huggingface")]
         for c in hf_cache_candidates:
-            if Path(c).is_dir():
+            if _is_dir_safe(Path(c)):
                 out["hf_cache"] = c
                 break
         if "hf_cache" not in out and create_missing_caches and hf_cache_candidates:
@@ -237,7 +253,7 @@ def detect_paths(
     else:
         cands = triton_cache_candidates if triton_cache_candidates is not None else _DEFAULT_TRITON_CACHE_CANDIDATES
         for c in cands:
-            if Path(c).is_dir():
+            if _is_dir_safe(Path(c)):
                 out["triton_cache"] = c
                 break
         if "triton_cache" not in out and create_missing_caches and cands:
@@ -252,7 +268,7 @@ def detect_paths(
     else:
         cands = compile_cache_candidates if compile_cache_candidates is not None else _DEFAULT_COMPILE_CACHE_CANDIDATES
         for c in cands:
-            if Path(c).is_dir():
+            if _is_dir_safe(Path(c)):
                 out["compile_cache"] = c
                 break
         if "compile_cache" not in out and create_missing_caches and cands:
@@ -267,7 +283,7 @@ def detect_paths(
     else:
         cands = sndr_src_candidates if sndr_src_candidates is not None else _DEFAULT_SNDR_SRC_CANDIDATES
         for c in cands:
-            if Path(c).is_dir():
+            if _is_dir_safe(Path(c)):
                 out["sndr_src"] = c
                 break
 
@@ -278,7 +294,7 @@ def detect_paths(
     else:
         cands = plugin_src_candidates if plugin_src_candidates is not None else _DEFAULT_PLUGIN_SRC_CANDIDATES
         for c in cands:
-            if Path(c).is_dir():
+            if _is_dir_safe(Path(c)):
                 out["plugin_src"] = c
                 break
 
@@ -289,7 +305,7 @@ def detect_paths(
     else:
         cands = cache_root_candidates if cache_root_candidates is not None else _DEFAULT_CACHE_ROOT_CANDIDATES
         for c in cands:
-            if Path(c).is_dir():
+            if _is_dir_safe(Path(c)):
                 out["cache_root"] = c
                 break
         if "cache_root" not in out and create_missing_caches and cands:

--- a/tests/unit/compat/test_pull_fit_gate.py
+++ b/tests/unit/compat/test_pull_fit_gate.py
@@ -117,6 +117,22 @@ def test_dry_run_proceeds_despite_insufficient_disk(capsys, monkeypatch):
     assert "✗ FAIL" in out
 
 
+def test_check_disk_space_uncreatable_dir_does_not_raise(monkeypatch):
+    """Regression (CI 2026-06-29): _check_disk_space mkdir'd the resolved
+    models dir unconditionally. On a runner whose models dir resolved to an
+    unwritable root (HUGGINGFACE_HUB_CACHE=/data/models, where /data can't be
+    created), mkdir raised PermissionError and crashed `sndr pull --dry-run`
+    before the fit verdict was ever printed. The check must REPORT the failure
+    (False, reason), never propagate the OSError."""
+    def boom(self, *args, **kwargs):
+        raise PermissionError(13, "Permission denied")
+
+    monkeypatch.setattr(pull.Path, "mkdir", boom)
+    ok, msg = pull._check_disk_space(pull.Path("/data/models"), needed_gb=10.0)
+    assert ok is False
+    assert "/data/models" in msg
+
+
 def test_dry_run_fake_gpus_fit(capsys):
     rc = pull.main(["qwen3_6_27b_int4_autoround", "--dry-run",
                     "--fake-gpus", "RTX A5000:24564:8.6"])

--- a/tests/unit/model_configs/test_host_src_candidates.py
+++ b/tests/unit/model_configs/test_host_src_candidates.py
@@ -11,6 +11,7 @@ _DEFAULT_PLUGIN_SRC_CANDIDATES (the repo root) but missed this sibling list.
 """
 from __future__ import annotations
 
+from sndr.model_configs import host
 from sndr.model_configs.host import (
     _DEFAULT_PLUGIN_SRC_CANDIDATES,
     _DEFAULT_SNDR_SRC_CANDIDATES,
@@ -38,3 +39,32 @@ def test_plugin_src_candidates_point_at_the_repo_root():
     bad = [c for c in _DEFAULT_PLUGIN_SRC_CANDIDATES
            if c.rstrip("/").endswith("/sndr")]
     assert not bad, f"plugin_src candidates must be the repo root, not sndr/: {bad}"
+
+
+def test_detect_paths_skips_permission_denied_candidate(monkeypatch):
+    # Regression (CI 2026-06-29): a default models candidate like /data/models
+    # exists but is permission-denied on a sandboxed CI runner. pathlib's
+    # Path.is_dir() PROPAGATES PermissionError (only missing/broken-symlink
+    # return False), so the probe crashed instead of skipping the candidate.
+    # An inaccessible candidate must be treated as "not usable" and skipped.
+    denied = "/denied/models"
+
+    def fake_is_dir(self):
+        if str(self) == denied:
+            raise PermissionError(13, "Permission denied")
+        return False  # nothing else "exists" in this isolated probe
+
+    monkeypatch.setattr(host.Path, "is_dir", fake_is_dir)
+
+    # Must NOT raise; the inaccessible candidate is simply omitted. Empty lists
+    # for the other vars isolate the probe to the single denied candidate.
+    out = host.detect_paths(
+        models_candidates=[denied],
+        hf_cache_candidates=[],
+        triton_cache_candidates=[],
+        compile_cache_candidates=[],
+        sndr_src_candidates=[],
+        plugin_src_candidates=[],
+        cache_root_candidates=[],
+    )
+    assert "models_dir" not in out

--- a/tools/audit_yaml_vs_runtime.sh
+++ b/tools/audit_yaml_vs_runtime.sh
@@ -24,7 +24,7 @@
 #   ./tools/audit_yaml_vs_runtime.sh --dump-config-keys <yaml_path>   # debug/test
 #
 # Examples:
-#   ./tools/audit_yaml_vs_runtime.sh sndr/model_configs/builtin/presets/prod-qwen3.6-35b-balanced.yaml vllm-qwen3.6-35b-balanced-k3 sander@192.168.1.10
+#   ./tools/audit_yaml_vs_runtime.sh sndr/model_configs/builtin/presets/prod-qwen3.6-35b-balanced.yaml vllm-qwen3.6-35b-balanced-k3 <user>@<host>
 #   ./tools/audit_yaml_vs_runtime.sh --dump-config-keys sndr/model_configs/builtin/presets/prod-qwen3.6-35b-balanced.yaml
 #
 # Exit codes:


### PR DESCRIPTION
The full `pytest` CI job has been **red on `main`** for several commits (`make gates` stays green because it runs a subset, not the full suite). Two independent causes:

## 1. `sndr pull --dry-run` crashes on an uncreatable models dir (4 failures)
`tests/unit/compat/test_pull_fit_gate.py::test_dry_run_*` → `pull.py:654 main` → `pull.py:77 _check_disk_space` → `Path.mkdir(parents=True)` → `PermissionError: '/data'`.

`_check_disk_space()` created the resolved models dir **unconditionally**. On a runner whose models dir resolves to an unwritable root (`HUGGINGFACE_HUB_CACHE=/data/models`, where `/data` can't be created), `mkdir` raised and crashed the dry-run *before* the fit verdict — defeating the existing dry-run leniency. **Fix:** catch `OSError` on `mkdir` and `disk_usage`, return `(False, reason)`. A `--dry-run` still reaches the verdict; a real pull exits `3` cleanly. + regression test that monkeypatches `mkdir` to raise and asserts no propagation.

## 2. `make audit` red → `test_make_evidence` aggregate gate blocks (1 failure)
`tests/unit/scripts/test_make_evidence.py::...test_aggregate_run_blocking_count_zero` asserts no blocking gate fails on the committed tree, but `audit` blocked: `audit-public-paths` flagged a real `sander@<lan-ip>` in a usage comment in `tools/audit_yaml_vs_runtime.sh`. **Fix:** redact to `<user>@<host>`.

## Also: host.py path-probe hardening (same error class, defense-in-depth)
`host.py` probed candidate dirs with `Path.is_dir()`, which **propagates** `PermissionError` (returns False only for missing/broken-symlink). Wrapped all probe sites in `_is_dir_safe()`. Not a cause of the current CI red, but the same permission-denied-dir failure mode one layer over; tested.

## Verification (local)
- Full suite: **14481 passed, 677 skipped, 1 documented xfail**.
- `scripts/make_evidence.py --json`: `blocking_failures: 0`.
- New regression tests fail before each fix, pass after.
- `make gates`: all 21 green.

Unblocks discoverability PR #34 (whose red `pytest`/`make_evidence` checks are these same pre-existing failures).