### PR TITLE
release: v12.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ build-backend = "setuptools.build_meta"
 name = "sndr-platform"
 # Source of truth: sndr/version.py __version__.
 # Bump there + here together on each release.
-version = "12.0.0"
+version = "12.1.0"
 description = "sndr-platform — multi-engine inference patch orchestrator (vLLM + SGLang)."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sndr/version.py
+++ b/sndr/version.py
@@ -15,7 +15,7 @@ publish workflow (see .github/workflows/release.yml).
 """
 from __future__ import annotations
 
-__version__: str = "12.0.0"
+__version__: str = "12.1.0"
 
 # Major version is the wire/contract version for license tokens and
 # engine adapter ABC compatibility. Customers' license tokens carry an


### PR DESCRIPTION
Version bump for the dev748/fleet/docs cycle. See release notes on the tag.