### PR TITLE
upstream 47609/47611/47593 integration + retirement code-audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,12 @@ Release-type tags in the title give the shape of the release at a glance:
 
 ## Version index (newest first)
 
+### [Unreleased] — post-v12.1.0 upstream watch: OPEN PRs 47609/47611/47593 triage + retirement code-audit
+
+| Tag | Date | Type | Summary |
+|---|---|---|---|
+| `[Unreleased]` | 2026-07-05 | dev | Six-step triage of three OPEN upstream PRs against dev748 (`0.23.1rc1.dev748+g2dfaae752`): **vllm#47609** (TurboQuant cache-dtype fix) = not needed on dev748 but wired as a **mechanical NEXT-bump gate** — its regression source vllm#42890 merged 2026-07-04 AFTER the dev748 cut, and any later pin **hard-fails boot on `--kv-cache-dtype turboquant_k8v4`** (both heavy lanes) unless #47609 is in; 2 new `UPSTREAM_MARKERS` (24 → 26) + 4 `tools/upstream_watchlist.yaml` rows incl. a ready-to-arm backport recipe and the bound G4_60E vendored-mirror re-study. **vllm#47611** (FlashInfer FP8 MoE signatures) = irrelevant — SM100-gated path, dormant on 2× A5000 SM86. **vllm#47593** (MoE M-tile heuristic) = irrelevant to stack — the fp8_w8a8 triton branch never executes on our Marlin/wna16 lanes; P24 anchor-collision audit recorded (anchor-1 already dead pre-existing, soft skip). Separately: operator-mandated **code re-verification of all 14 recent retirements** (pristine dev748 tree + dev714 image greps + fresh `gh pr view` batch) — **14/14 CORRECT, zero reinstatements**; PN383 filename-vs-monolith precision note added. Registry unchanged at **325**; no new patches, flags, or config changes |
+
 ### v12.1.0 series — dev748 pin, 7-model fleet sweep, ctx-scaling bench stage, operator manuals
 
 | Tag | Date | Type | Summary |
@@ -124,6 +130,100 @@ previous / rollback pin per the CLAUDE.md ≤2-pin policy; dev672 was dropped
 when dev748 was validated. `sndr/version.py` carries the `.dev0` suffix
 in-tree; release tooling strips it on publish — pyproject.toml holds the
 release version.)
+
+---
+
+## [Unreleased] — upstream 47609/47611/47593 triage + retirement code-audit (2026-07-05)
+
+Post-v12.1.0 upstream-watch work on the dev748 pin
+(`0.23.1rc1.dev748+g2dfaae752`, cut commit 2dfaae752 =
+2026-07-03T04:11:47Z). No new patches, no registry changes, no new env
+flags — the deliverables are mechanical next-bump gates, watchlist
+rows, and a code-proven retirement audit.
+
+### Highlights
+
+- **vllm#47609 wired as a mechanical NEXT-bump boot-blocker gate.**
+  Its regression source vllm#42890 merged 2026-07-04T02:29Z — AFTER
+  the dev748 cut — so dev748 itself is clean (verified on the pristine
+  rig tree: `v1/worker/gpu/attn_utils.py` has no `KVQuantMode.NONE`
+  conditional; `cache_dtype_str` passes through untouched). But ANY
+  candidate pin cut after 2026-07-04 makes the v1 reshape pass
+  `cache_dtype_str="auto"` for TurboQuant specs and **hard-fails boot
+  on `--kv-cache-dtype turboquant_k8v4`** — both heavy lanes (27B INT4
+  TQ k8v4 + PN520, and 35B where TQ k8v4 is a +11.3% TPS win) —
+  unless #47609 (maintainer fix, `ready`-labeled) is also in.
+  Wired, not memorized: 2 new `UPSTREAM_MARKERS` entries
+  (`PR_42890_kv_skip_layers_cache_dtype_auto` regression-arrival with
+  documented inverse semantics + `PR_47609_tq_cache_dtype_preserved`
+  fix-arrival; marker strings byte-exact from the PR diffs, both
+  verified ABSENT on pristine dev748 → no false `newly_merged` today)
+  and 4 sweep rows in `tools/upstream_watchlist.yaml`, including a
+  ready-to-arm backport recipe (two `layer_cache_dtype = (` anchor
+  sites, next-pin-only lower bound) armed only if #47609 is still
+  unmerged at bump time. The `pr: 42890` row also binds a re-study of
+  the vendored `_reshape_kv_cache` mirror in
+  `g4_60e_kv_cache_utils.py` (goes stale on the carrying pin).
+- **Retirement code-audit: 14/14 CORRECT, zero reinstatements.**
+  Operator-mandated re-verification BY CODE (not words) of every
+  patch retired 2026-07-03..05: PN394, P61b, P64, PN287, PN8, PN387,
+  PN398, PN370, PN383, PN252, PN362, PN373, PN379, G4_80. Evidence:
+  pristine dev748 tree line-reads (rig `/tmp/pristine_dev748_2dfaae752`),
+  `docker run --rm` greps on the dev714 image itself for the three
+  `<dev714` range caps, and a fresh `gh pr view` state batch (11 PRs:
+  #46047 MERGED, #40849 still OPEN → PN8's NOT-absorbed claim holds,
+  9 absorbed PRs MERGED). One nuance closed: a file NAMED
+  `offloading_connector.py` still exists on dev748 as a ~215-line
+  delegating shell — the 0.22.x monolith PN383's 12 anchors target is
+  what is gone; precision note added to the PN383 docstring so the
+  surviving filename is never misread as a wrong retirement.
+
+### Audit findings (per-PR verdicts)
+
+- **vllm#47609** (TurboQuant cache-dtype preserved in backend shape) —
+  `not-needed-on-dev748`; MANDATORY next-bump gate item (see
+  Highlights). Prefer the upstream merge over the Genesis backport per
+  iron rule #10 exception logic; re-check `gh pr view 47609` at bump
+  time.
+- **vllm#47611** (older FlashInfer FP8 MoE signatures) — IRRELEVANT.
+  Source #45723 IS in dev748 (unconditional `gemm1_alpha=` at
+  `trtllm_fp8_moe.py:234/405` verified) but the `TrtLlmFp8Experts`
+  dispatch is SM100/Blackwell-gated (`trtllm_fp8_moe.py:98-99`);
+  A5000 = SM86 never selects it; our FP8 lanes run Marlin MoE; no
+  Genesis patch touches the file. Watch-only row so future sweeps
+  skip the re-study.
+- **vllm#47593** (tokens-per-expert M-tile heuristic) — IRRELEVANT to
+  stack. The rewritten fp8_w8a8 `[128,128]` triton branch never
+  executes on our lanes (FP8 Marlin / AWQ Marlin / wna16; decode M
+  under the unchanged `M<=64` floor at `max_num_seqs=2`). NOT in
+  dev748. Anchor-collision audit: P24's anchor-1 targets the exact
+  rewritten line but is ALREADY dead on dev748 (pre-existing
+  #46642-era drift, `required=False` soft skip); anchor-2 untouched;
+  PN377 disjoint; P81 = outcome (c) different problem (dense
+  `w8a8_triton_block_scaled_mm`, different file) — both kept.
+  Housekeeping flag recorded: P24's fp8-branch overlay is a silent
+  no-op on dev748 (dormant by design on Marlin lanes).
+
+### Migration notes
+
+None. No env flags, YAML keys, or launch configs changed. The
+`docs/PIN_BUMP_PLAYBOOK.md` §4 note ("Armed gate for the NEXT bump")
+is the operator-visible artifact; stale `docs/PATCHES.md` #44784
+"OPEN upstream" note corrected to MERGED-native (PN383 retired).
+
+### Verified
+
+- TDD: `tests/unit/dispatcher/test_open_pr_triage_47609_47611_47593.py`
+  written first, seen red, now 7/7 green.
+- `make gates` exit 0; watchlist-check + `--check-registry` + legacy
+  watchlist audit clean; tools/compat/dispatcher suites 1234 passed;
+  docstring-sync gate green; 0 new ruff on touched files.
+- Retirement suites (`test_newly_merged_triage_2026_07_05.py`,
+  `test_retire_batch_2026_07_05.py`) 13/13 green.
+- Six-step evidence chain (gh pr view/diff for
+  47609/47611/47593/42890/45723/47431; pristine-tree greps; registry
+  cross-ref P24/P81/PN377/PN352B/G4_60E) carried in the commit
+  messages.
 
 ---
 

--- a/docs/PATCHES.md
+++ b/docs/PATCHES.md
@@ -229,15 +229,20 @@ specific flag path against dev748 before relying on it.
     `gpu_block_size % hash_block_size == 0`). Our 27B PROD profile
     runs prefix caching OFF — offload stays blocked there until that
     constraint is lifted or the profile changes.
-  - **MTP spec-decode + native offload is broken in this pin**: the
-    `OffloadingConnectorScheduler` wrongly includes EAGLE/MTP
+  - **MTP spec-decode + native offload was broken in 0.22.x-era pins**:
+    the `OffloadingConnectorScheduler` wrongly included EAGLE/MTP
     draft-attention groups in load/store scheduling → out-of-bounds
-    GPU block index → `cuMemcpyBatchAsync` segfault. Fix is OPEN
-    upstream (vllm#44784, `is_eagle_group` skip + pre-DMA bounds
-    check) and NOT in the pin; Wave-2 vendor planned (see
-    `docs/superpowers/journal/2026-06-11-pr-sweep-50-roadmap.md`,
-    Theme 5). Until then, KV offload remains a no-go on our MTP PROD
-    configs (K=5 on 35B / K=4 on 27B as of 2026-07).
+    GPU block index → `cuMemcpyBatchAsync` segfault. The upstream fix
+    vllm#44784 MERGED 2026-06-16 and is native (and evolved) in dev748:
+    `is_eagle_group` is a first-class `KVCacheGroup` field set by the
+    engine core (`v1/core/kv_cache_utils.py`) and consumed by
+    `kv_connector/v1/offloading/scheduler.py`, plus a scheduler-level
+    volatile-trailing-block exclusion that removes the OOB source at
+    its root. The Genesis vendor of the fix (PN383) is retired;
+    retirement re-verified by code on the pristine dev748 tree
+    2026-07-05. MTP + native offload has NOT yet been exercised on our
+    lanes — validate on a throwaway container before enabling it on
+    the MTP PROD configs (K=5 on 35B / K=4 on 27B as of 2026-07).
   - Frees GPU VRAM worth ~tens of K context at the cost of CPU↔GPU
     PCIe traffic on miss; payoff is prefix-reuse on agent loops
     (second-pass TTFT restore instead of full prefill).

--- a/docs/PIN_BUMP_PLAYBOOK.md
+++ b/docs/PIN_BUMP_PLAYBOOK.md
@@ -165,7 +165,7 @@ md5+diff patches MUST follow this attribute convention.
 
 Plus three tree-wide passes:
 
-- **`UPSTREAM_MARKERS`** (24-entry table in
+- **`UPSTREAM_MARKERS`** (26-entry table in
   `sndr/engines/vllm/upstream_compat.py`) — `newly_merged` hits feed the
   iron-rule-#11 queue and count as actionable.
 - **Version ranges** — every spec's `applies_to.vllm_version_range`
@@ -223,6 +223,27 @@ For every `UPSTREAM_MERGED` / `SUB_UPSTREAM_MERGED` row and every
      `vllm_version_range` + `superseded_by`),
    - ours does MORE → update patch, keep the extras,
    - different approach → keep, verify anchors clean.
+
+**Armed gate for the NEXT bump (recorded 2026-07-05, dev748 current):**
+any candidate pin cut after 2026-07-04 carries vllm#42890 (merged
+2026-07-04T02:29Z, AFTER the dev748 cut), which makes the v1 reshape
+pass `cache_dtype_str="auto"` whenever `kv_quant_mode == NONE` —
+TurboQuant specs (`TQFullAttentionSpec`) map to `NONE` while still
+needing the real dtype string, so `--kv-cache-dtype turboquant_k8v4`
+lanes (BOTH heavy lanes: 27B INT4 TQ and 35B) **HARD-FAIL BOOT** with
+`Unknown TurboQuant cache dtype: 'auto'` unless the fix vllm#47609 is
+also in the candidate (or its Genesis backport is applied first).
+Mechanical detection: `UPSTREAM_MARKERS`
+`PR_42890_kv_skip_layers_cache_dtype_auto` (regression arrival) and
+`PR_47609_tq_cache_dtype_preserved` (fix arrival) fire `newly_merged`
+in this preflight. Full triage + the ready-to-arm backport recipe (two
+`layer_cache_dtype = (` anchor sites in
+`vllm/v1/worker/gpu/attn_utils.py`) live in
+`tools/upstream_watchlist.yaml` rows `pr: 42890` / `pr: 47609`.
+The `pr: 42890` row also binds a re-study of the vendored
+`_reshape_kv_cache` mirror in
+`sndr/engines/vllm/patches/attention/turboquant/g4_60e_kv_cache_utils.py`,
+which goes stale on the pin that carries #42890.
 
 ## 5. Boot smoke on a THROWAWAY container
 

--- a/sndr/engines/vllm/patches/offload/pn383_offload_mtp_eagle_gate.py
+++ b/sndr/engines/vllm/patches/offload/pn383_offload_mtp_eagle_gate.py
@@ -11,6 +11,14 @@ source the pre-DMA bounds check defended against). The 0.22.x
 ``offloading_connector.py`` monolith these anchors target no longer exists
 (split into the ``offloading/`` package). Kept for reference.
 
+Precision note (retirement re-verified by code 2026-07-05): a file NAMED
+``offloading_connector.py`` still exists on dev748, but it is a ~215-line
+delegating shell importing from the ``offloading/`` package — the 0.22.x
+single-file implementation these anchors target is what is gone. Do not
+mistake the surviving filename for a wrong retirement: the native gating
+lives in ``offloading/scheduler.py`` (``is_eagle_group`` field :92, use
+:174/:215/:512; volatile-trailing-block exclusion :89-90, :490).
+
 Upstream #44784 (issue #44780): ``OffloadingConnectorScheduler`` schedules
 EAGLE/MTP draft-attention groups into the store/load paths. The draft
 group's trailing block is rewritten by the drafter every decode step (no

--- a/sndr/engines/vllm/upstream_compat.py
+++ b/sndr/engines/vllm/upstream_compat.py
@@ -11,7 +11,6 @@ Author: Sandermage(Sander)-Barzov Aleksandr, Ukraine, Odessa
 """
 from __future__ import annotations
 
-
 # Upstream PR → marker string mapping.
 #
 # Each value is a marker string that, if present in the target file's
@@ -382,6 +381,52 @@ UPSTREAM_MARKERS: dict[str, dict[str, str]] = {
         "affects_patch": "P17/P18 Marlin bsm env override — watch for anchor break",
         "verified_in_main_2026_04_24": False,
         "action_when_merged": "update anchor paths in marlin_tuning wiring",
+    },
+
+    # INVERSE-SEMANTICS marker (regression ARRIVAL, not fix absorption):
+    # a newly_merged hit here means the candidate pin carries the #42890
+    # TQ boot-blocker, NOT that a Genesis patch can retire. Marker string
+    # is byte-exact from the #42890 diff (gh pr diff, 2026-07-05) and
+    # verified ABSENT in pristine dev748 attn_utils.py (no KVQuantMode
+    # reference in the file at all), so it cannot false-fire on the
+    # current pin.
+    "PR_42890_kv_skip_layers_cache_dtype_auto": {
+        "file": "v1/worker/gpu/attn_utils.py",
+        "marker": "if kv_cache_spec.kv_quant_mode == KVQuantMode.NONE",
+        "description": (
+            "BOOT-BLOCKER ARRIVAL: #42890 (kv_cache_dtype_skip_layers, "
+            "MERGED 2026-07-04 — after the dev748 cut) passes "
+            "cache_dtype_str='auto' for KVQuantMode.NONE; TurboQuant "
+            "dtypes map to NONE while TQFullAttentionSpec needs the real "
+            "'turboquant_k8v4' string -> startup ValueError on both TQ "
+            "k8v4 heavy lanes. When this fires on a candidate pin, "
+            "REQUIRE the #47609 fix marker to fire too (or backport it, "
+            "see the upstream_watchlist #47609 row) AND re-study the "
+            "G4_60E vendored _reshape_kv_cache mirror."
+        ),
+        "merged_date": "2026-07-04 (NOT in dev748, cut 2026-07-03)",
+        "affects_patch": (
+            "none to retire — gates the bump itself (TQ k8v4 boot) and "
+            "stales the G4_60E mirror"
+        ),
+    },
+
+    "PR_47609_tq_cache_dtype_preserved": {
+        "file": "v1/worker/gpu/attn_utils.py",
+        "marker": "and not isinstance(kv_cache_spec, TQFullAttentionSpec)",
+        "description": (
+            "Fix arrival for the #42890 TQ boot-blocker: TQFullAttention"
+            "Spec excluded from the KVQuantMode.NONE 'auto' rewrite in "
+            "_reshape_kv_cache + _update_hybrid_attention_layout. When "
+            "this fires alongside PR_42890_* the candidate boots TQ k8v4 "
+            "lanes; if #42890 fires WITHOUT this, the bump is blocked "
+            "until #47609 (or the planned Genesis backport) is in."
+        ),
+        "merged_date": "OPEN as of 2026-07-05 (maintainer PR, ready label)",
+        "affects_patch": (
+            "planned TQ cache-dtype backport (see upstream_watchlist "
+            "#47609 row) — retire the plan when this fires"
+        ),
     },
 }
 

--- a/tests/unit/dispatcher/test_open_pr_triage_47609_47611_47593.py
+++ b/tests/unit/dispatcher/test_open_pr_triage_47609_47611_47593.py
@@ -1,0 +1,154 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Open-PR triage 2026-07-05 — vllm#47609 / #47611 / #47593 verdicts.
+
+Pins the six-step adjudication of the three OPEN upstream PRs studied on
+2026-07-05 (gh pr view/diff captured; pristine dev748 tree line-reads on
+the rig /tmp/pristine_dev748_2dfaae752, _version.py verified
+0.23.1rc1.dev748+g2dfaae752):
+
+  #47609 [Bugfix][TurboQuant] preserve KV cache dtype in backend shape —
+         NOT needed on dev748 (attn_utils.py has no KVQuantMode.NONE
+         conditional; cache_dtype passes straight through at :308) but a
+         MANDATORY next-bump gate item: its regression source #42890
+         (MERGED 2026-07-04, AFTER the dev748 cut 2026-07-03T04:11Z)
+         makes the v1 reshape pass cache_dtype_str='auto' for
+         KVQuantMode.NONE while TQFullAttentionSpec still needs the real
+         'turboquant_k8v4' string -> engine startup ValueError. BOTH
+         heavy lanes run TQ k8v4, so any pin cut after 2026-07-04
+         HARD-FAILS BOOT unless #47609 (or an equivalent backport) is in.
+         Gate wiring pinned here: two UPSTREAM_MARKERS entries (regression
+         arrival + fix arrival, byte-exact strings from the PR diffs,
+         both verified ABSENT on pristine dev748) + sweep rows for #47609
+         and #42890 (the latter binding the G4_60E vendored-mirror
+         re-study — g4_60e_kv_cache_utils.py mirrors the exact
+         _reshape_kv_cache logic #42890 rewrites).
+
+  #47611 [Bugfix][MoE] older FlashInfer FP8 MoE signatures — IRRELEVANT:
+         regression source #45723 IS in dev748 (unconditional gemm1_alpha
+         at trtllm_fp8_moe.py:234/405) but the dispatch is gated
+         is_device_capability_family(100) + has_flashinfer_trtllm_fused_moe
+         (trtllm_fp8_moe.py:98-99) = Blackwell SM100 only; 2x A5000 =
+         SM86 never selects TrtLlmFp8Experts. No Genesis patch touches
+         trtllm_fp8_moe.py. Recorded as a sweep row so future sweeps do
+         not re-study it.
+
+  #47593 [Kernel][Perf] tokens-per-expert M-tile heuristic — IRRELEVANT
+         to the current stack: the fp8_w8a8 [128,128] triton branch it
+         rewrites never executes on our rig (Ampere FP8 MoE -> FP8
+         Marlin; 35B PROD AWQ Marlin; G4 26B WNA16 branch untouched;
+         decode M under the unchanged M<=64 floor). Anchor-collision
+         audited: P24 anchor-1 targets the exact line #47593 rewrites but
+         is ALREADY dead on dev748 (pre-existing #46642-era drift, soft
+         required=False skip); #47593 does not touch P24's live anchor-2
+         region. P81 = idea-family overlap, different kernel/file,
+         outcome (c) both keep.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT))
+
+WATCHLIST = REPO_ROOT / "tools" / "upstream_watchlist.yaml"
+
+# Byte-exact strings from the PR diffs (gh pr diff 42890 / 47609,
+# captured 2026-07-05). Both verified ABSENT in pristine dev748
+# vllm/v1/worker/gpu/attn_utils.py so neither marker can false-fire as
+# newly_merged on the current pin.
+MARKER_42890 = "if kv_cache_spec.kv_quant_mode == KVQuantMode.NONE"
+MARKER_47609 = "and not isinstance(kv_cache_spec, TQFullAttentionSpec)"
+ATTN_UTILS_REL = "v1/worker/gpu/attn_utils.py"
+
+
+def _sweep_rows() -> dict[int, dict]:
+    import yaml
+    doc = yaml.safe_load(WATCHLIST.read_text(encoding="utf-8"))
+    return {row["pr"]: row for row in doc.get("sweep", [])}
+
+
+def test_sweep_rows_exist_for_all_three_prs_plus_regression_source():
+    rows = _sweep_rows()
+    for pr in (47609, 42890, 47611, 47593):
+        assert pr in rows, f"missing sweep row for vllm#{pr}"
+        assert rows[pr]["trigger"] == "review-on-merge", (
+            f"vllm#{pr}: expected advisory review-on-merge, got "
+            f"{rows[pr]['trigger']!r}"
+        )
+
+
+def test_47609_row_records_the_boot_blocker_gate():
+    """The #47609 row is the pin-bump preflight watchlist item: it must
+    name the regression source, the TQ k8v4 boot-blocker class, and the
+    backport plan for the still-unmerged case."""
+    row = _sweep_rows()[47609]
+    # No vendored patch yet — backport only if still unmerged at bump time.
+    assert row["genesis_patch"].lower().startswith("planned:")
+    note = row["note"]
+    for needle in ("42890", "turboquant_k8v4", "BOOT", "layer_cache_dtype = ("):
+        assert needle in note, f"#47609 note missing {needle!r}"
+
+
+def test_42890_row_binds_the_g4_60e_mirror_restudy():
+    """#42890 entering a pin stales the G4_60E vendored mirror of
+    _reshape_kv_cache — the row must bind that re-study to a LIVE patch."""
+    row = _sweep_rows()[42890]
+    assert "G4_60E" in row["genesis_patch"]
+    note = row["note"]
+    for needle in ("_reshape_kv_cache", "47609", "g4_60e_kv_cache_utils"):
+        assert needle in note, f"#42890 note missing {needle!r}"
+    # The bound patch must be live (review rows are not tool-checked).
+    from sndr.dispatcher.registry import PATCH_REGISTRY
+    assert PATCH_REGISTRY["G4_60E"]["lifecycle"] != "retired"
+
+
+def test_47611_row_records_sm100_dormancy():
+    row = _sweep_rows()[47611]
+    assert row["genesis_patch"] == "watch-only"
+    note = row["note"]
+    for needle in ("45723", "SM100", "SM86", "trtllm_fp8_moe.py"):
+        assert needle in note, f"#47611 note missing {needle!r}"
+
+
+def test_47593_row_records_dormant_branch_and_p24_audit():
+    row = _sweep_rows()[47593]
+    assert "P24" in row["genesis_patch"]
+    note = row["note"]
+    for needle in ("fp8_w8a8", "Marlin", "P81", "46642"):
+        assert needle in note, f"#47593 note missing {needle!r}"
+    # P24 must still be live for the note's anchor facts to stay auditable.
+    from sndr.dispatcher.registry import PATCH_REGISTRY
+    assert PATCH_REGISTRY["P24"]["lifecycle"] != "retired"
+
+
+def test_new_rows_pass_the_sweep_schema():
+    sys.path.insert(0, str(REPO_ROOT / "tools"))
+    from check_upstream_watchlist import load_sweep, validate_rows
+    rows = load_sweep(WATCHLIST)
+    assert validate_rows(rows) == []
+
+
+def test_upstream_markers_gate_the_42890_boot_blocker():
+    """Mechanical next-bump gate: the preflight marker walk must flag
+    newly_merged the moment a candidate pin carries #42890 (regression
+    arrival) and, independently, #47609 (fix arrival)."""
+    from sndr.engines.vllm.upstream_compat import UPSTREAM_MARKERS
+
+    reg = {k: v for k, v in UPSTREAM_MARKERS.items() if "42890" in k}
+    assert len(reg) == 1, "expected exactly one PR_42890 marker entry"
+    entry = next(iter(reg.values()))
+    assert entry["file"] == ATTN_UTILS_REL
+    assert entry["marker"] == MARKER_42890
+    # A regression-arrival marker must never be pre-waived as known-merged.
+    assert not any(entry.get(k) for k in entry
+                   if k.startswith("verified_in_main_"))
+    assert "47609" in entry["description"]
+
+    fix = {k: v for k, v in UPSTREAM_MARKERS.items() if "47609" in k}
+    assert len(fix) == 1, "expected exactly one PR_47609 marker entry"
+    fentry = next(iter(fix.values()))
+    assert fentry["file"] == ATTN_UTILS_REL
+    assert fentry["marker"] == MARKER_47609
+    assert not any(fentry.get(k) for k in fentry
+                   if k.startswith("verified_in_main_"))

--- a/tools/upstream_watchlist.yaml
+++ b/tools/upstream_watchlist.yaml
@@ -1348,4 +1348,74 @@ sweep:
     checklist + rationale: docs/PR45413_QWEN3_PARSER_DEEPDIFF_PREP.md.
     review-on-merge is advisory and intentionally NOT registry-bound, so this prep row records the decision
     inputs the mechanical drift detector cannot infer; it does NOT pre-commit any retire/keep outcome.'
+- pr: 42890
+  genesis_patch: G4_60E
+  trigger: review-on-merge
+  note: 'NEXT-BUMP BOOT-BLOCKER SOURCE (deep-studied 2026-07-05; MERGED 2026-07-04T02:29Z — AFTER the
+    dev748 cut 2026-07-03T04:11Z, so NOT in dev748; verified by pristine-tree grep on the rig:
+    attn_utils.py has no KVQuantMode.NONE conditional, line 308 passes cache_dtype_str=cache_dtype
+    straight through). #42890 (kv_cache_dtype_skip_layers) makes the v1 reshape pass
+    cache_dtype_str="auto" whenever kv_quant_mode == KVQuantMode.NONE; TurboQuant dtypes map to
+    KVQuantMode.NONE while TQFullAttentionSpec still needs the real turboquant_k8v4 string for the
+    backend shape -> engine startup ValueError "Unknown TurboQuant cache dtype: auto" = HARD BOOT FAIL
+    on --kv-cache-dtype turboquant_k8v4. BOTH heavy lanes run TQ k8v4 (27B INT4 TQ k8v4+PN520 ~130 t/s;
+    35B where TQ k8v4 = +11.3% TPS), so ANY pin cut after 2026-07-04 is a boot-blocker unless the fix
+    #47609 (see its own row) is also in the pin. Mechanical detection: UPSTREAM_MARKERS
+    PR_42890_kv_skip_layers_cache_dtype_auto fires newly_merged on the carrying pin. SECONDARY impact
+    bound to G4_60E: sndr/engines/vllm/patches/attention/turboquant/g4_60e_kv_cache_utils.py (vendor of
+    OPEN vllm#45181) runtime-wraps vllm.v1.worker.gpu.attn_utils._reshape_kv_cache and carries a vendored
+    MIRROR of its logic ("Mirror gpu/attn_utils._reshape_kv_cache") — when #42890 (+#47609) enters the
+    pin that mirror is STALE and G4_60E must be re-studied (gemma4 padded-page lanes). No Genesis patch
+    text-anchors attn_utils.py, so no anchor drift; the wrapped function SEMANTICS change.'
+- pr: 47609
+  genesis_patch: 'planned: TQ cache-dtype preservation backport (attention.turboquant) — only if still
+    unmerged at bump time'
+  trigger: review-on-merge
+  note: 'PIN-BUMP PREFLIGHT GATE ITEM (deep-studied 2026-07-05; OPEN, author LucasWilkinson = maintainer,
+    labels bug/ready -> likely merges). Fix for the #42890 TQ boot-blocker (see the #42890 row): adds
+    "and not isinstance(kv_cache_spec, TQFullAttentionSpec)" to the two KVQuantMode.NONE conditionals in
+    vllm/v1/worker/gpu/attn_utils.py (_reshape_kv_cache + _update_hybrid_attention_layout), 6 lines.
+    NOT needed on dev748 (the #42890 region does not exist there — verified on the pristine rig tree).
+    AT BUMP TIME, for any candidate pin cut after 2026-07-04: (1) gh pr view 47609 — if MERGED and in the
+    candidate, nothing to do beyond the G4_60E mirror re-study; (2) if still UNMERGED, the candidate
+    HARD-FAILS BOOT on turboquant_k8v4 lanes — backport as a NEW attention.turboquant patch anchored on
+    the two "layer_cache_dtype = (" sites (BOTH sites needed; anchors structural; dual-variant NOT
+    required since dev748 lacks the region entirely — the patch is next-pin-only with a lower
+    vllm_version_range bound). Mechanical detection: UPSTREAM_MARKERS PR_47609_tq_cache_dtype_preserved
+    fires newly_merged when the fix lands in a candidate tree.'
+- pr: 47611
+  genesis_patch: watch-only
+  trigger: review-on-merge
+  note: 'IRRELEVANT TO GENESIS (deep-studied 2026-07-05; OPEN). Handles older FlashInfer wheels lacking
+    the gemm1_alpha/gemm1_beta/gemm1_clamp_limit kwargs that #45723 (MERGED 2026-07-01, IS in dev748 —
+    verified unconditional gemm1_alpha= at trtllm_fp8_moe.py:234/405 in the pristine tree) passes
+    unconditionally -> TypeError at startup on old FlashInfer (nightly CI: gpt-oss-20b 0.0 accuracy,
+    Qwen3-30B FP8 startup timeouts). Fix = functools.cache-d inspect.signature probe; narrower
+    alternative to the wholesale draft revert #47431 (OPEN). Dormant on our rig despite the regression
+    source being in dev748: the TrtLlmFp8Experts dispatch is gated is_device_capability_family(100) +
+    has_flashinfer_trtllm_fused_moe() (trtllm_fp8_moe.py:98-99) = Blackwell SM100 only; 2x A5000 = SM86
+    never selects it. Our FP8 35B alt lane runs FP8 Marlin MoE (MarlinExpertsBase, PN352B registry
+    evidence); 35B PROD is AWQ Marlin; no Genesis patch touches trtllm_fp8_moe.py (grep clean). No
+    backport, no watch burden unless Blackwell hardware arrives.'
+- pr: 47593
+  genesis_patch: P24
+  trigger: review-on-merge
+  note: 'IRRELEVANT TO CURRENT STACK, ANCHOR-AUDITED (deep-studied 2026-07-05; OPEN). Changes
+    get_default_config fp8_w8a8 block-quant [128,128] BLOCK_SIZE_M rule "M<=64" -> "M<=64 or
+    M*topk<16*E" (keep the 16-row tile while the avg expert sees <1 full tile), CUDA-only; ROCm +
+    batched per-expert-M callers keep the old rule via a new m_is_per_expert plumb. Benched geomean
+    1.295x on H20 / 1.015x on 4090D at M=96-768 for high-E MoEs. NOT in dev748 (fused_moe.py:1285 still
+    has the raw rule). The rewritten branch NEVER EXECUTES on our rig: Ampere FP8 MoE dispatches to FP8
+    Marlin (not the triton fp8_w8a8 block branch); 35B PROD is AWQ/wna16-Marlin; G4 26B WNA16 MoE uses
+    the int4_w4a16 branch (untouched, already keys on M*topk via should_moe_wna16_use_cuda); decode M at
+    max_num_seqs=2 sits under the unchanged M<=64 floor anyway. ANCHOR COLLISION AUDIT: P24 anchor-1
+    (_OLD_FP8_CFG) targets the EXACT line #47593 rewrites, but that anchor is ALREADY dead on dev748
+    (pre-existing #46642-era refactor drift: "BLOCK_SIZE_N: block_shape[0]" -> block_n; anchor is
+    required=False so it soft-skips today); only P24 anchor-2 (general branch) applies and #47593 does
+    NOT touch that region. PN377 (_ensure_block_size_k_divisible, wna16 branch) disjoint. Net: if
+    #47593 merges, ZERO additional drift. HOUSEKEEPING (pre-existing): P24 fp8-branch num_warps overlay
+    is a silent no-op on dev748 — re-anchor only if the fp8 triton MoE branch ever becomes live for us
+    (on Marlin lanes it is dormant by design, P24 docstring). Idea-family overlap with P81 (backport of
+    OPEN vllm#40925 — same small-M-tile-for-decode reasoning but for the DENSE
+    w8a8_triton_block_scaled_mm kernel, different file) = outcome (c) different problem, both keep.'
 __sentinel__: complete


### PR DESCRIPTION
# upstream 47609/47611/47593 integration + retirement code-audit

Post-v12.1.0 upstream-watch window on the dev748 pin
(`0.23.1rc1.dev748+g2dfaae752`, cut 2026-07-03T04:11:47Z). Six-step
study/analyze/verify/search/compare discipline; evidence chains carried
in the per-commit messages. **No new patches, no registry changes, no
new env flags, no YAML/config changes** — deliverables are mechanical
next-bump gates, watchlist rows, one docstring precision note, and doc
sync.

## Per-PR integration verdicts

| Upstream PR | Verdict | Action taken |
|---|---|---|
| vllm#47609 (TurboQuant cache-dtype preserved in backend shape) | **not-needed-on-dev748; MANDATORY next-bump gate** — regression source vllm#42890 merged 2026-07-04 AFTER the dev748 cut; any later pin hard-fails boot on `--kv-cache-dtype turboquant_k8v4` (both heavy lanes) unless #47609 is in | 2 new `UPSTREAM_MARKERS` (24 → 26: `PR_42890_kv_skip_layers_cache_dtype_auto` regression-arrival + `PR_47609_tq_cache_dtype_preserved` fix-arrival; byte-exact strings, verified ABSENT on pristine dev748) + watchlist rows with a ready-to-arm backport recipe (two `layer_cache_dtype = (` sites, next-pin-only) + bound G4_60E vendored-mirror re-study |
| vllm#47611 (older FlashInfer FP8 MoE signatures) | **irrelevant** — source #45723 IS in dev748 but the `TrtLlmFp8Experts` dispatch is SM100/Blackwell-gated; A5000 = SM86 never selects it; no Genesis patch touches the file | watch-only watchlist row (future sweeps skip the re-study) |
| vllm#47593 (tokens-per-expert M-tile heuristic) | **irrelevant-to-stack** — the rewritten fp8_w8a8 triton branch never executes on Marlin/wna16 lanes; NOT in dev748 | watchlist row recording the P24 anchor-collision audit (anchor-1 already dead pre-existing, soft skip; anchor-2 untouched), P24 fp8-branch no-op housekeeping flag, P81 outcome-(c) record |

## Retirement code-audit (operator-mandated, BY CODE)

All 14 retirements from 2026-07-03..05 re-proven against the pristine
dev748 tree + `docker run --rm` greps on the dev714 image + a fresh
`gh pr view` batch (11 PRs): **14/14 CORRECT, zero reinstatements.**
PN394, P61b, P64, PN287, PN8, PN387, PN398, PN370, PN383, PN252,
PN362, PN373, PN379, G4_80. One nuance closed: a file NAMED
`offloading_connector.py` still exists on dev748 (a ~215-line
delegating shell) — the 0.22.x monolith PN383's anchors target is what
is gone; docstring precision note added so the surviving filename is
never misread as a wrong retirement.

## Docs

- CHANGELOG: `[Unreleased]` section + version-index row.
- `docs/PIN_BUMP_PLAYBOOK.md`: `UPSTREAM_MARKERS` 24 → 26; new §4
  "Armed gate for the NEXT bump" note (the #42890/#47609 TQ
  boot-blocker + G4_60E mirror re-study).
- `docs/PATCHES.md`: stale "vllm#44784 OPEN upstream / vendor planned"
  note corrected to MERGED-native (2026-06-16), PN383 retired.
- No BENCHMARKS changes (no new numbers); no config/YAML changes (no
  new flags/params introduced).

## Verified

- TDD: `tests/unit/dispatcher/test_open_pr_triage_47609_47611_47593.py`
  written first, seen red, 7/7 green.
- `make gates` exit 0; `check_doc_sync --strict` green (325);
  docstring-sync green; 0 new ruff on touched files.
- Full local pytest suite on the final branch state:
  **14832 passed / 707 skipped / 1 xfailed / 0 failed** (exit 0,
  2026-07-05).
