### PR TITLE
fix(stale-range): drive _BASELINE_CRITICAL_STALE waiver 12 -> 1

### DIFF
--- a/docs/PATCHES.md
+++ b/docs/PATCHES.md
@@ -37,11 +37,11 @@ added as a registry patch.
 | Tier=community (Apache 2.0, sndr) | **324** (all entries) |
 | Tier=engine (commercial, sndr_engine) | **0** (PN72 reclassified to community 2026-05-08; sndr_engine namespace reserved but empty) |
 | Default-on at boot | 56 |
-| Lifecycle=experimental | 228 |
+| Lifecycle=experimental | 221 |
 | Lifecycle=legacy (pre-dispatcher) | 28 |
-| Lifecycle=retired | 52 |
+| Lifecycle=retired | 60 |
 | Lifecycle=research | 3 |
-| Lifecycle=stable | 14 (G4_01, G4_02, G4_03, G4_04, G4_05 [retired], G4_09, G4_11, G4_12, G4_13, G4_14, G4_16, G4_23, G4_25, PN33, PN35 — ratchet active with `stable_kind` declared; see [CONTRIBUTING.md § Promoting a patch to lifecycle=stable](CONTRIBUTING.md#promoting-a-patch-to-lifecyclestable)) |
+| Lifecycle=stable | 13 (G4_01, G4_02, G4_03, G4_04, G4_05 [retired], G4_09, G4_11, G4_12, G4_13, G4_16, G4_23, G4_25, PN33, PN35 — ratchet active with `stable_kind` declared; G4_14 retired 2026-07-05; see [CONTRIBUTING.md § Promoting a patch to lifecycle=stable](CONTRIBUTING.md#promoting-a-patch-to-lifecyclestable)) |
 | Lifecycle=coordinator | 4 (env-flag-only, no real binding) |
 | Implementation status=full | 267 |
 | Implementation status=marker_only / placeholder / partial / retired | 37 (22 + 2 + 7 + 6) |

--- a/docs/PATCHES_AUTO.md
+++ b/docs/PATCHES_AUTO.md
@@ -4,7 +4,7 @@
 > Source of truth: `sndr/dispatcher/registry.py`.
 > Companion to curated [PATCHES.md](PATCHES.md) (which has narrative + tombstones + engine boundary discussion).
 
-Generated: 2026-07-05T12:16:54Z
+Generated: 2026-07-05T15:05:35Z
 Total entries: **329**
 
 ## Statistics
@@ -14,13 +14,13 @@ Total entries: **329**
 
 ### By lifecycle
 - `lifecycle=coordinator`: **4**
-- `lifecycle=experimental`: **228**
+- `lifecycle=experimental`: **221**
 - `lifecycle=legacy`: **28**
 - `lifecycle=research`: **3**
-- `lifecycle=retired`: **52**
-- `lifecycle=stable`: **14**
+- `lifecycle=retired`: **60**
+- `lifecycle=stable`: **13**
 
-### Default-on at boot: **58** / 329
+### Default-on at boot: **56** / 329
 
 ### By family
 - `attention`: 2
@@ -80,7 +80,7 @@ Total entries: **329**
 | **P63** | `community` | `retired` | · | `GENESIS_ENABLE_P63_MTP_GDN_STATE_RECOVERY` | — | MTP/Eagle drafter GDN state recovery (RETIRED — hypothesis disproven 2026-04-25) |
 | **P103** | `community` | `experimental` | · | `GENESIS_ENABLE_P103` | — | FLA Cliff 2 chunked fwd_h+fwd_o orchestrator (qwen36-27b-single-3090#1) |
 | **PN11** | `community` | `experimental` | · | `GENESIS_ENABLE_PN11_GDN_AB_CONTIGUOUS` | [#41142](https://github.com/vllm-project/vllm/pull/41142) | GDN a/b contiguity in fix_query_key_value_ordering (vllm#41142) |
-| **PN30** | `community` | `experimental` | · | `GENESIS_ENABLE_PN30_DS_LAYOUT_SPEC_DECODE` | — | "DS conv state layout + spec-decode AL>1 fix (issue |
+| **PN30** | `community` | `retired` | · | `GENESIS_ENABLE_PN30_DS_LAYOUT_SPEC_DECODE` | — | "DS conv state layout + spec-decode AL>1 fix (issue |
 | **PN32** | `community` | `experimental` | · | `GENESIS_ENABLE_PN32_GDN_CHUNKED_PREFILL` | — | GDN _forward_core chunked-prefill v2 (Cliff 2 fix for single-24GB-GPU OOM) |
 | **PN50** | `community` | `experimental` | · | `GENESIS_ENABLE_PN50_GDN_FUSED_PROJ` | — | GDN proj fusion (SGLang#21019 backport — Qwen3.5/3.6 contiguous-projection Tr... |
 | **PN54** | `community` | `retired` | · | `GENESIS_ENABLE_PN54_GDN_CONTIGUOUS_DEDUP` | — | GDN contiguous-call deduplication (P0.7 Cliff 2b OOM mitigation) — RETIRED 20... |
@@ -222,7 +222,7 @@ Total entries: **329**
 | **G4_11** | `community` | `stable` | ✓ | `GENESIS_ENABLE_G4_11_GEMMA4_CHAT_TEMPLATE_INSTALL` | — | Gemma 4 enhanced chat template install |
 | **G4_12** | `community` | `stable` | ✓ | `GENESIS_ENABLE_G4_12_GEMMA4_FP8_E4NV_GUARD` | [#41014](https://github.com/vllm-project/vllm/issues/41014) | Refuse FP8 e4nv on Ampere SM 8.6 (closes vllm#41014) |
 | **G4_13** | `community` | `stable` | ✓ | `GENESIS_ENABLE_G4_13_GEMMA4_PER_TOKEN_HEAD_KV_GUARD` | [#40388](https://github.com/vllm-project/vllm/issues/40388) | Refuse asymmetric per-layer KV-head config (closes vllm#40388 silent corruption) |
-| **G4_14** | `community` | `stable` | ✓ | `GENESIS_ENABLE_G4_14_GEMMA4_TOOL_CALL_PARSER_PAD` | [#39392](https://github.com/vllm-project/vllm/issues/39392) | Gemma 4 tool-call parser pad-token strip (closes vllm#39392) |
+| **G4_14** | `community` | `retired` | · | `GENESIS_ENABLE_G4_14_GEMMA4_TOOL_CALL_PARSER_PAD` | [#39392](https://github.com/vllm-project/vllm/issues/39392) | Gemma 4 tool-call parser pad-token strip (closes vllm#39392) |
 | **G4_15** | `community` | `experimental` | · | `GENESIS_ENABLE_G4_15_GEMMA4_FUSED_RMSNORM` | — | Fused RMSNorm Triton kernels for Gemma 4 (ported from SGLang) |
 | **G4_16** | `community` | `stable` | ✓ | `GENESIS_ENABLE_G4_16_GEMMA4_FULL_AND_PIECEWISE` | — | Gemma 4 FULL_AND_PIECEWISE cudagraph mode (parallel to PN125 for gemma4) |
 | **G4_17** | `community` | `experimental` | · | `GENESIS_ENABLE_G4_17_GEMMA4_VISION_SKIP` | — | Gemma 4 vision-tower text-only skip |
@@ -259,7 +259,7 @@ Total entries: **329**
 | **PN96** | `community` | `experimental` | · | `GENESIS_ENABLE_PN96_EMERGENCY_DEMOTE` | — | PN96 — emergency-demote hook (Phase 6 PoC; allocator intercept) |
 | **PN97** | `community` | `experimental` | · | `GENESIS_ENABLE_PN97_TENSOR_PHYSICAL_CAP` | — | PN97 — physical-cap on KV tensor allocation (Phase 7 PoC) |
 | **PN106** | `community` | `experimental` | · | `GENESIS_ENABLE_PN106_GDN_H_POOL` | — | PN106 — GDN scratch tensor pool (architectural memory mgr) |
-| **PN110** | `community` | `experimental` | ✓ | `GENESIS_ENABLE_PN110` | [#42615](https://github.com/vllm-project/vllm/pull/42615) | BlockPool.free_blocks deduplication (vllm#42615) |
+| **PN110** | `community` | `retired` | · | `GENESIS_ENABLE_PN110` | [#42615](https://github.com/vllm-project/vllm/pull/42615) | BlockPool.free_blocks deduplication (vllm#42615) |
 | **PN346** | `community` | `experimental` | ✓ | `GENESIS_ENABLE_PN346` | [#43650](https://github.com/vllm-project/vllm/pull/43650) | Mamba/GDN cache hit boundary fix for MTP + prefix caching (vendor of OPEN vll... |
 | **PN346B** | `community` | `experimental` | ✓ | `GENESIS_ENABLE_PN346B` | [#45614](https://github.com/vllm-project/vllm/pull/45614) | Mamba/GDN + EAGLE/MTP + APC coordinator curr_hit_length clamp (coordinator ha... |
 | **PN382** | `community` | `experimental` | · | `GENESIS_ENABLE_PN382_DECODE_BENCH_HYBRID_FILL` | [#45080](https://github.com/vllm-project/vllm/pull/45080) | DecodeBenchConnector hybrid per-block KV fill (vendor of vllm#45080) |
@@ -372,7 +372,7 @@ Total entries: **329**
 
 | ID | Tier | Lifecycle | Default | Env flag | Upstream PR | Title |
 |---|---|---|:---:|---|:---:|---|
-| **PN347** | `community` | `experimental` | · | `GENESIS_ENABLE_PN347` | [#44113](https://github.com/vllm-project/vllm/pull/44113) | MarlinFP8 N==K silent corruption correctness fix (vendor of CLOSED vllm#44113... |
+| **PN347** | `community` | `retired` | · | `GENESIS_ENABLE_PN347` | [#44113](https://github.com/vllm-project/vllm/pull/44113) | MarlinFP8 N==K silent corruption correctness fix (vendor of CLOSED vllm#44113... |
 | **PN-FP8MOE-KPAD** | `community` | `experimental` | · | `GENESIS_ENABLE_PN_FP8MOE_KPAD` | [#45703](https://github.com/vllm-project/vllm/pull/45703) | FP8 MoE intermediate thread-tile pad (FP8-core backport of OPEN vllm#45703) |
 
 ### `reasoning` (7)
@@ -443,7 +443,7 @@ Total entries: **329**
 | **PN40** | `community` | `experimental` | · | `GENESIS_ENABLE_PN40_DFLASH_OMNIBUS` | — | Spec-decode omnibus (A DFlash K-norm + B pool + C adaptive K + D sentinel) |
 | **PN72** | `community` | `experimental` | · | `GENESIS_ENABLE_PN72_FREQUENCY_NGRAM_DRAFTER` | — | Frequency-based ngram draft post-filter (llama.cpp-style) |
 | **PN90** | `community` | `experimental` | · | `GENESIS_ENABLE_PN90_PROBABILISTIC_DRAFT` | [#40269](https://github.com/vllm-project/vllm/pull/40269) | Probabilistic draft rejection (vllm#40269 backport) — propagate draft_probs t... |
-| **PN133** | `community` | `experimental` | · | `GENESIS_ENABLE_PN133_MTP_EMPTY_OUTPUT_FIX` | [#42722](https://github.com/vllm-project/vllm/pull/42722) | MTP scheduler empty-output accounting fix (backport vllm#42722) |
+| **PN133** | `community` | `retired` | · | `GENESIS_ENABLE_PN133_MTP_EMPTY_OUTPUT_FIX` | [#42722](https://github.com/vllm-project/vllm/pull/42722) | MTP scheduler empty-output accounting fix (backport vllm#42722) |
 | **PN256** | `community` | `experimental` | · | `GENESIS_ENABLE_PN256_KPLUS1_RAW_KV` | — | K+1 spec-verify routing through raw-K/V continuation prefill (PR42637 overlay... |
 | **PN262** | `community` | `experimental` | · | `GENESIS_ENABLE_PN262_FLASH_ATTN_DRAFTER_TRACE` | — | FlashAttn drafter KV cache shape/stride trace + fail-fast (PN261-D D-3 locali... |
 | **PN262B** | `community` | `experimental` | · | `GENESIS_ENABLE_PN262B_KV_ALLOC_TRACE` | — | KV cache allocator/reshape/proposer-init diagnostic trace (PN262-A D-3 deep-d... |
@@ -457,7 +457,7 @@ Total entries: **329**
 | **PN363** | `community` | `experimental` | · | `GENESIS_ENABLE_PN363` | [#43114](https://github.com/vllm-project/vllm/pull/43114) | force_max_spec_tokens for suffix decoding — FULL CG dispatch (vendor of OPEN ... |
 | **PN370** | `community` | `retired` | · | `GENESIS_ENABLE_PN370_ASYNC_ACCEPT_RACE` | [#45100](https://github.com/vllm-project/vllm/pull/45100) | Async spec-decode accepted-counts race fix (vendor of OPEN vllm#45100) |
 | **PN372** | `community` | `experimental` | · | `GENESIS_ENABLE_PN372_EAGLE_ZERO_SEQLEN_GUARD` | [#45005](https://github.com/vllm-project/vllm/pull/45005) | eagle_step zero/negative-seqlen slot-mapping guard (vendor of OPEN vllm#45005) |
-| **PN378** | `community` | `experimental` | · | `GENESIS_ENABLE_PN378_VOCAB_PAD_MASK` | [#45060](https://github.com/vllm-project/vllm/pull/45060) | Recovered-token vocab-pad -inf mask (vendor of vllm#45060, kernel half) |
+| **PN378** | `community` | `retired` | · | `GENESIS_ENABLE_PN378_VOCAB_PAD_MASK` | [#45060](https://github.com/vllm-project/vllm/pull/45060) | Recovered-token vocab-pad -inf mask (vendor of vllm#45060, kernel half) |
 | **PN380** | `community` | `experimental` | · | `GENESIS_ENABLE_PN380_MTP_PREFUSED_LOADER` | [#44943](https://github.com/vllm-project/vllm/pull/44943) | Qwen3.5/3.6 MTP pre-fused expert loader + load-coverage guard (vendor of vllm... |
 | **PN381** | `community` | `experimental` | · | `GENESIS_ENABLE_PN381_ALLOWED_TOKEN_IDS_METADATA` | [#44742](https://github.com/vllm-project/vllm/pull/44742) | allowed_token_ids spec-decode metadata hardening (vendor of vllm#44742) |
 | **PN390** | `community` | `experimental` | · | `GENESIS_ENABLE_PN390_STREAMING_LSE_SAMPLER` | [#45369](https://github.com/vllm-project/vllm/pull/45369) | Streaming-LSE rejection sampler — no full-vocab target_probs materialize (ven... |
@@ -493,7 +493,7 @@ Total entries: **329**
 | **P29** | `community` | `legacy` | ✓ | `GENESIS_LEGACY_P29` | — | tool parser IndexError guard |
 | **P64** | `community` | `retired` | · | `GENESIS_ENABLE_P64_QWEN3CODER_MTP_STREAMING` | [#39598](https://github.com/vllm-project/vllm/pull/39598) | qwen3coder_tool_parser consolidated: MTP streaming early-return fix (vllm#395... |
 | **PN287** | `community` | `retired` | · | `GENESIS_ENABLE_PN287_QWEN3CODER_ARGS_OBSERVER` | — | "qwen3_coder × MTP arg-corruption frequency observer (club-3090 |
-| **PN374** | `community` | `experimental` | · | `GENESIS_ENABLE_PN374_QWEN3XML_QUOTED_KEYS` | [#44877](https://github.com/vllm-project/vllm/pull/44877) | "qwen3xml quoted parameter-name strip (Gemma4 |
+| **PN374** | `community` | `retired` | · | `GENESIS_ENABLE_PN374_QWEN3XML_QUOTED_KEYS` | [#44877](https://github.com/vllm-project/vllm/pull/44877) | "qwen3xml quoted parameter-name strip (Gemma4 |
 | **PN375** | `community` | `experimental` | · | `GENESIS_ENABLE_PN375_GEMMA4_MULTIBOUNDARY_STREAMING` | [#44741](https://github.com/vllm-project/vllm/pull/44741) | Gemma4 multi-boundary streaming tool-call deltas under MTP (vllm#44741) |
 | **PN385** | `community` | `experimental` | · | `GENESIS_ENABLE_PN385_FORCED_NAMED_EMPTY_PARAMS` | [#45290](https://github.com/vllm-project/vllm/pull/45290) | Forced-named empty-params tool schema -> JSON object (vendor of vllm#45290) |
 | **PN386** | `community` | `retired` | · | `GENESIS_ENABLE_PN386_REQUIRED_STREAMING_STRING_AWARE` | — | Required-tool streaming brace JSON-string-awareness (vendor of vllm#45389) |
@@ -501,7 +501,7 @@ Total entries: **329**
 | **PN394** | `community` | `retired` | · | `GENESIS_ENABLE_PN394_QWEN3_PARTIAL_PARAM_LT_FIX` | [#46047](https://github.com/vllm-project/vllm/pull/46047) | qwen3 partial-param value `<` truncation fix (vllm#46047) |
 | **PN525** | `community` | `experimental` | ✓ | `GENESIS_ENABLE_PN525_NONSTREAM_TOOLCALL_MARKUP_DROP` | [#47562](https://github.com/vllm-project/vllm/pull/47562) | Drop incomplete tool-call markup in non-streaming to match streaming (vendor ... |
 | **G4_T1** | `community` | `experimental` | · | `GENESIS_INFO_G4_T1_PR42006_OVERLAY_MOUNTED` | [#42006](https://github.com/vllm-project/vllm/pull/42006) | "Gemma4 tool-parser PR |
-| **P29_HEAL** | `community` | `experimental` | · | `GENESIS_ENABLE_P29_QWEN3CODER_INDEX_HEAL` | — | qwen3coder tool parser index heal (P29 companion, fix-wire 2026-06-04) |
+| **P29_HEAL** | `community` | `retired` | · | `GENESIS_ENABLE_P29_QWEN3CODER_INDEX_HEAL` | — | qwen3coder tool parser index heal (P29 companion, fix-wire 2026-06-04) |
 
 ### `worker` (15)
 

--- a/scripts/audit_stale_vllm_version_ranges.py
+++ b/scripts/audit_stale_vllm_version_ranges.py
@@ -76,11 +76,12 @@ DEFAULT_PIN = "0.23.1rc1.dev748+g2dfaae752"  # static last-resort fallback; keep
 #   3. Remove the patch ID from this set + add a one-line "verified
 #      on pin <X> via bench <Y>" note in commit message.
 _BASELINE_CRITICAL_STALE: frozenset[str] = frozenset({
-    # Default-on (always-skip without env override) — exactly 1 entry:
-    # PN252 (security; see its note at the end of this set — kept default_on
-    # to protect by default on rollback pins, engine-superseded on 0.23.x).
-    # legacy `legacy`/`retired` lifecycles are filtered out by `_audit` so do
-    # not appear here.
+    # Default-on (always-skip without env override) — ZERO entries: PN252,
+    # the sole former default_on member, was formally RETIRED 2026-07-05
+    # (lifecycle=retired) once vllm#45252 (GHSA-33cg-gxv8-3p8g) was verified
+    # engine-native on pristine dev748 — see the breadcrumb at the end of this
+    # set. `legacy`/`retired`/`deprecated` lifecycles are filtered out by
+    # `_audit`, so retired patches never surface here and need no baseline row.
     #
     # v11.3.0 BUG #14 follow-through (commit pending): empirically
     # verified on rig 0.21.1rc1 via direct apply() probe — 17 of the
@@ -109,13 +110,28 @@ _BASELINE_CRITICAL_STALE: frozenset[str] = frozenset({
     # enabled in builtin YAMLs — pre-existing debt unrelated to the
     # wave-2 registry integration, queued for per-patch re-verification
     # on 0.22.1 before the range is bumped (audit workflow step 1):
-    "PN90",   # probabilistic-draft MTP; ('>=0.20.2rc1.dev9', '<0.22.0').
-              # Self-skips via drift marker on merged-equivalent upstream
-              # (intentional), so the YAML "enable" is already a no-op by
-              # design — verify on 0.22.1, then bump or retire.
-    "PN125",  # warmup-orchestrator FULL_AND_PIECEWISE; ('>=0.20.0',
-              # '<0.22.0'), Qwen3.5/Next arch-gated. Needs a 0.22.1 boot
-              # probe before the upper bound moves to <0.23.0.
+    # PN90 removed 2026-07-05 (verified by code on pristine dev748): all 4
+    # anchors gone (runner `None,  # draft_probs` literal absent -> apply()
+    # self-retires; proposer _greedy_sample gained a use_heterogeneous_vocab
+    # branch) and upstream #40269 native symbols present -> PN90 self-skips.
+    # All model YAMLs now set the flag '0' and the QA profile disables it, so
+    # PN90 is WARN (not CRITICAL) at dev748 — its CRITICAL-waiver entry was
+    # vestigial. Kept lifecycle=experimental (NOT retired: related_not_
+    # superseding, test-locked in test_audit_upstream_status EXPECTED_SPECIAL;
+    # #40269 is a different-approach landing empirically rejected on our shape).
+    # Dropping it re-arms the guard: re-enabling the flag to '1' now trips
+    # --strict instead of being silently waived.
+    # PN125 CLEARED 2026-07-05 (dev748 reverify): anchor PRESENT+APPLICABLE on
+    # 0.23.1rc1.dev748 — Qwen3_5ForConditionalGenerationConfig + MambaModelConfig
+    # .verify_and_update_config both live in vllm.model_executor.models.config and
+    # MODELS_CONFIG_MAP routes both our arches to the target (verified via
+    # `docker run --rm nightly-2dfaae752`). apply() returns "applied". The
+    # config-class gap PN125 targets is NOT closed natively (class still only sets
+    # mamba_ssm_cache_dtype); the FULL_AND_PIECEWISE effect is redundant with the
+    # v1 resolver but harmless, and the patch is deliberately kept ON in 4 YAMLs as
+    # upstream-bypass insurance. Range bumped <0.22.0 -> <0.24.0 (registry.py) so
+    # the insurance installs on dev748 instead of being version-gate-skipped.
+    # Anchor present => BUMP not RETIRE; no longer stale-debt.
     #
     # 2026-06-14: DELIBERATE cross-pin gates (NOT debt-to-bump). The four
     # entries below are capped '<0.22.1rc1.dev491' ON PURPOSE by the
@@ -136,40 +152,87 @@ _BASELINE_CRITICAL_STALE: frozenset[str] = frozenset({
     # would have re-engaged and corrupted the native parser. #45588 DELETED
     # tool_parsers/qwen3coder_tool_parser.py + the gemma4 parser; the engine
     # state machine supersedes. Skip 0.23.x, apply <0.23.0 (dev259 rollback).
-    # P64 formally RETIRED 2026-07-03 (lifecycle=retired) — auto-excluded here.
-    "P61c",   # qwen3_coder deferred-commit streaming wrap — same #45588 parser
-              # deletion; engine state machine supersedes.
-    "PN56",   # qwen3_coder XML-fallback streaming wrap — same #45588 parser
-              # deletion; engine state machine supersedes.
-    "PN347",  # MarlinFP8 N==K corruption fix. dev491 REFACTORED the buggy
-              # `if w_q.shape != (...)` transpose guard out of
-              # kernels/linear/scaled_mm/marlin.py (transpose moved to caller
-              # via the explicit `size_k_first` contract) so the bug cannot
-              # occur and the anchor is correctly absent; the dev259 image
-              # still has the guard at marlin.py:87. vllm#44113 CLOSED-unmerged
-              # (upstream solved it structurally). Skip dev491, apply dev259.
+    # P64/P61c/PN56 formally RETIRED 2026-07-03 (consolidated into the single
+    # registry entry "P64", lifecycle=retired, capped <0.23.0). All three patch
+    # the DELETED tool_parsers/qwen3coder_tool_parser.py (#45413/#45171/#45588,
+    # merged 2026-06-15). PN56 verified by code 2026-07-05 on pristine dev748
+    # (2dfaae752): the file — and the whole entrypoints/openai/tool_parsers/
+    # dir — is GONE; only the engine-native vllm/tool_parsers/
+    # qwen3_engine_tool_parser.py remains, so _make_pn56_patcher() resolves no
+    # target and the wrap is inert. As a retired entry P64 is auto-excluded from
+    # _audit (lifecycle filter), so none of the three can surface as a CRITICAL
+    # row — no baseline waiver is needed (PN30/PN373/P64 retire precedent).
+    # P61c removed 2026-07-05: consolidated into P64 (env_flag_alias, not a
+    # standalone registry id) and P64 is lifecycle=retired + auto-excluded, so
+    # the audit can never emit a P61c CRITICAL — the waiver row was vestigial.
+    # Verified by code on pristine dev748 (2dfaae752): qwen3coder_tool_parser.py
+    # DELETED, P61C_ANCHOR_OLD (is_tool_call_started) 0 matches tree-wide.
+    # PN347 formally RETIRED 2026-07-05 (lifecycle=retired, superseded by the
+    # structural size_k_first caller-contract refactor at dev491+ that DELETED
+    # its `w_q.shape != (...)` anchor — verified by code on pristine dev748) —
+    # now auto-excluded by _audit, so no baseline entry is needed.
     # ── 0.23.1 reverify 2026-06-17 (Workflow + adversarial verify) ──────
     # Intentionally capped <0.23.0 on the 0.23.1 pin — each verified live.
     # (a) Upstream supersedes on 0.23.x (the fix shipped / the bug is gone):
-    "PN30",   # DS conv spec-decode — upstream fused-postprocess kernel rewrote
-              # get_conv_copy_spec (iron-rule #11a). Skip 0.23.1, apply <0.23.0.
-    "PN133",  # MTP scheduler empty-output — pre-fix anchor gone on 0.23.1.
-    "PN362",  # VLLM_TRITON_FORCE_FIRST_CONFIG — merged into 0.23.x.
-    "PN370",  # async accepted-counts race — superseded by our 0.23.1-native PN398.
-    "PN373",  # parallel_tool_calls null — vllm#44955 merged into 0.23.x.
-    "PN378",  # recovered-token vocab mask — complete vllm#45060 ships in 0.23.1.
-    "PN383",  # offload MTP/EAGLE gate — vllm#44784 merged 2026-06-16 (0.23.x).
-    "PN51",   # qwen3 enable_thinking routing — merged into 0.23.x.
-    "P29_HEAL",            # heals the qwen3coder parser DELETED by #45588.
-    "G4_14",  # gemma4 pad-strip wraps Gemma4ToolParser, DELETED by #45588. New
-              # Gemma4EngineToolParser is a skip_special_tokens=False rewrite —
-              # #39392 raw-token pad-leak mode no longer exists. Skip 0.23.1,
-              # apply <0.23.0 (iron-rule #11a). #39392 still OPEN: redesign vs
-              # the new class with a failing repro test before lifting the cap.
-    "SNDR_MTP_DYNAMIC_K_001",  # #26504 DynamicProposer — bench NOT_SIGNIFICANT.
-    # (b) Bug still live on 0.23.1 but the anchor target was refactored away —
-    # capped pending a redesign (cannot byte-exact re-anchor; see registry):
-    "PN374",  # qwen3xml quoted-keys — bug fixed upstream; anchors gone.
+    # PN30 formally RETIRED 2026-07-05 (lifecycle=retired) — the DS conv
+    # spec-decode NotImplementedError anchor is GONE on dev748 (upstream
+    # fused-postprocess kernel; the `assert offset == 0` form re-verified by
+    # code on pristine 2dfaae752, mamba_utils.py:305-310), so PN30 is
+    # auto-excluded from this audit and no longer needs a baseline entry
+    # (P64/P61b/PN287 retire precedent).
+    # PN133 formally RETIRED 2026-07-05 (lifecycle=retired) — vllm#42722's
+    # accounting fix is native on dev748 (scheduler.py:1585-1593); pre-fix
+    # anchor PN133_OLD gone (grep 0). Auto-excluded by _audit, no baseline row.
+    # PN362 formally RETIRED 2026-07-05 (lifecycle=retired) — vllm#42425 merged
+    # 2026-06-16 ships vllm/triton_utils/force_first_config.py natively on
+    # dev748. Auto-excluded by _audit, no baseline row.
+    # PN370 formally RETIRED 2026-07-05 (lifecycle=retired) — vllm#45100 merged;
+    # native `batch_size = m.num_reqs` + `needs_cpu_accepted_counts` guard on
+    # pristine dev748. Auto-excluded by _audit, no baseline row.
+    # PN373 (parallel_tool_calls null, vllm#44955 merged 2026-06-15) formally
+    # RETIRED 2026-07-05 (lifecycle=retired) — `is not False` + the merged
+    # docstring verified native in pristine dev748 tool_calls_utils.py:22-24;
+    # auto-excluded from _audit, so no baseline entry needed (P64/P61b/PN287 class).
+    # PN378 formally RETIRED 2026-07-05 (lifecycle=retired) — the complete
+    # vllm#45060 (mask + OOV clamp) is native in pristine dev748
+    # rejection_sampler.py L945/L952; dev259 splice anchor gone (count 0).
+    # Auto-excluded by _audit, no baseline row.
+    # PN383 formally RETIRED 2026-07-05 (lifecycle=retired) — vllm#44784 merged
+    # 2026-06-16; eagle-group offload gating is native+evolved in pristine
+    # dev748 offloading/scheduler.py. Auto-excluded by _audit, no baseline row.
+    # PN51 (qwen3 enable_thinking=false streaming content routing, vllm#40816,
+    # fixed upstream by #40820) was CONSOLIDATED into P61b on 2026-06-20 (it is
+    # an env_flag_alias, not a standalone registry key) and P61b is
+    # lifecycle=retired — so PN51 never surfaces as an _audit row and this
+    # allowlist line suppressed nothing. Superseded on dev748 by the
+    # #45413/#45588 parser-engine refactor: reasoning/qwen3_reasoning_parser.py
+    # (PN51's target) is DELETED and the anchor text is absent tree-wide on
+    # pristine 2dfaae752 — the engine-native qwen3_engine_reasoning_parser.py
+    # owns thinking-disabled routing. Baseline entry removed 2026-07-05
+    # (P64/P61b/PN287/PN30/PN373 retire precedent).
+    # P29_HEAL formally RETIRED 2026-07-05 (lifecycle=retired, superseded by
+    # #45413/#45171/#45588 — target file + anchors gone on pristine dev748).
+    # Auto-excluded by _audit, no baseline row.
+    # G4_14 formally RETIRED 2026-07-05 (lifecycle=retired, default_on=False):
+    # Gemma4ToolParser is DELETED by #45588; the surviving Gemma4EngineToolParser
+    # is a skip_special_tokens=False rewrite so the #39392 raw-token pad-leak
+    # mode is gone. _find_gemma_tool_parser() misses -> graceful no-op. Cap kept
+    # <0.23.0 (anchor GONE, NOT bumped). Auto-excluded by _audit, no baseline
+    # row. #39392 still OPEN: redesign vs the new class with a failing repro
+    # test before lifting the cap.
+    # SNDR_MTP_DYNAMIC_K_001 formally RETIRED (lifecycle=retired) — superseded by
+    # native Dynamic SD (vllm#32374, MERGED 2026-06-14) verified in-pin on
+    # pristine dev748 (vllm/v1/spec_decode/dynamic/utils.py: "Dynamic SD batch-size
+    # schedule"). The DraftModelProposer monkey-patch target still exists
+    # (draft_model.py:19) but the #26504 port is redundant and bench NOT_SIGNIFICANT.
+    # Auto-excluded from _audit (lifecycle=retired), so no baseline entry needed
+    # (P64/PN30/PN373 retire precedent). default_on=False.
+    # PN374 formally RETIRED 2026-07-05 (lifecycle=retired, superseded by the
+    # #45588 parser-engine refactor that DELETED tool_parsers/
+    # qwen3xml_tool_parser.py; native vllm/parser/qwen3.py json.dumps escapes
+    # keys+values so the quoted-key corruption cannot occur — verified by code
+    # on pristine dev748). Auto-excluded from _audit (WARN-only anyway, never
+    # enabled by a builtin YAML/compose), so no baseline entry is needed.
     # ── 0.23.1 dev148 full-patch audit 2026-06-18 ──────────────────────
     "PN66",   # multiturn </think> leak fix. Re-verified live on dev748
               # 2026-07-05: DelegatingParser is PRESENT (not gone) but the
@@ -183,24 +246,29 @@ _BASELINE_CRITICAL_STALE: frozenset[str] = frozenset({
               # (chat_template.jinja:100-104) STRIPS prior-turn reasoning from
               # history, so no stale </think> enters prompt_token_ids in normal
               # multiturn. #41696 CLOSED-unmerged. Skip 0.23.x, apply <0.23.0.
-    "PN110",  # BlockPool dedup (#42615 OPEN) — SimpleCPUOffload-only path,
-              # dormant on our non-offload PROD; anchor drifted on 0.23.x.
+    # PN110 — RETIRED 2026-07-05 (lifecycle=retired, auto-excluded from this
+    #   audit). By-code verify on pristine dev748 (block_pool.py:614): the
+    #   free_blocks region PN110 anchored on is GONE (LRU-split rewrite) and
+    #   the new per-block `if block.ref_cnt == 0` append-guard structurally
+    #   prevents the double-append symptom. #42615 OPEN but SimpleCPUOffload-
+    #   only; non-offload PROD. See registry superseded_by. Cap <0.23.0 kept.
     # P61b + PN287 formally RETIRED 2026-07-03 (lifecycle=retired, superseded by
     # the #45413/#45588 parser-engine refactor that DELETED their target files —
     # verified live on dev714) — now auto-excluded from this audit, so they no
     # longer need a baseline entry.
-    # The ONE default_on=True allowlist entry (see the "Default-on" note at the
-    # top of this set). PN252 is a SECURITY patch (M-RoPE prompt_embeds-only DoS,
-    # GHSA-33cg-gxv8-3p8g) — kept default_on so it protects by default on every
-    # rollback pin <0.23.0 where the buggy fatal assert still exists. vllm#45252
-    # MERGED at/before b4c80ec0f (dev148): _init_mrope_positions now derives a
-    # non-None input_tokens (range over prompt_embeds for embeds-only) + raises a
-    # per-request ValueError instead of the fatal assert — the DoS is closed by
-    # the engine, so PN252's anchors are correctly absent on 0.23.x and it
-    # version-gate-skips. Cap <0.23.0 + this allowlist entry are the intentional,
-    # verified-2026-06-19 record (engine fix at gpu_model_runner.py:1648/1652).
-    # Skip 0.23.x, apply <0.23.0 (dev259/dev491 rollback).
-    "PN252",
+    # PN252 (M-RoPE prompt_embeds-only DoS, GHSA-33cg-gxv8-3p8g) formally
+    # RETIRED 2026-07-05 (lifecycle=retired, superseded by vllm#45252 MERGED
+    # 2026-06-13). By-code re-verification on pristine dev748 (2dfaae752):
+    # _init_mrope_positions at gpu_model_runner.py:1607-1637 is the engine-
+    # native fix verbatim — NO fatal `assert prompt_token_ids is not None`,
+    # instead `input_tokens` is derived from prompt_token_ids-or-prompt_embeds-
+    # length else a per-request ValueError; the fatal assert survives only in
+    # the sibling _init_xdrope_positions (line 1642), which PN252 never
+    # targeted. Both PN252 required anchors count=0 on pristine dev748, so the
+    # patcher self-skips. lifecycle=retired → auto-excluded from `_audit`, so no
+    # baseline row is needed (P64/P61b/PN287/PN373/PN110 class). The default_on-
+    # enable flag was also removed from the a5000-2x hardware YAML the same day,
+    # closing the "enabled flag on a version-gated no-op" landmine.
 })
 
 

--- a/scripts/audit_v2_patch_lifecycle.py
+++ b/scripts/audit_v2_patch_lifecycle.py
@@ -135,6 +135,37 @@ ALLOWED_RETIRED_PATCHES: dict[str, str] = {
         "fp8kv YAML; capped <0.23.0 + target gone → self-skips on the deployed "
         "pin. Cleaned from YAMLs at next config audit."
     ),
+    # ── 2026-07-05: stale-range baseline drive-to-zero retire batch. Each is
+    # superseded/native on dev748 (anchor GONE, verified by code on pristine
+    # 2dfaae752) but kept enabled in its model YAMLs as <0.23.0 rollback
+    # insurance; lifecycle=retired makes the dispatcher skip it and the target
+    # is gone on the deployed pin, so leaving the env set is doubly harmless.
+    # Cleaned out of YAMLs at next config audit cycle.
+    "PN30": (
+        "Retired 2026-07-05 — superseded by the upstream fused-postprocess "
+        "kernel (get_conv_copy_spec rewritten; NotImplementedError anchor GONE "
+        "on dev748). Enabled in qwen3.6-27b int4-autoround-fp8kv / tq-k8v4 + "
+        "35b-a3b-fp8 YAMLs; capped <0.23.0 → self-skips on the deployed pin."
+    ),
+    "PN110": (
+        "Retired 2026-07-05 — superseded by the free_blocks LRU-split refactor "
+        "(anchor region GONE on dev748; per-block ref_cnt==0 append-guard "
+        "prevents the double-append symptom). Enabled in gemma4 26B/31B + "
+        "qwen3.6 27B/35B YAMLs; capped <0.23.0 → self-skips on the deployed pin."
+    ),
+    "PN133": (
+        "Retired 2026-07-05 — vllm#42722 accounting fix native on dev748 "
+        "(scheduler.py:1585-1593; pre-fix anchor GONE). Enabled in qwen3.6 27B "
+        "dflash / tq-k8v4 + 35B a3b-fp8 / dflash YAMLs; capped <0.23.0 → "
+        "self-skips on the deployed pin."
+    ),
+    "G4_14": (
+        "Retired 2026-07-05 — Gemma4ToolParser DELETED by #45588; the "
+        "surviving Gemma4EngineToolParser is a skip_special_tokens=False "
+        "rewrite so the #39392 pad-leak mode is gone (anchor GONE on dev748). "
+        "Enabled in gemma-4 26B/31B AWQ YAMLs; capped <0.23.0 + finder misses "
+        "the deleted class → graceful no-op on the deployed pin."
+    ),
 }
 
 

--- a/sndr/dispatcher/registry.py
+++ b/sndr/dispatcher/registry.py
@@ -2152,7 +2152,29 @@ PATCH_REGISTRY: dict[str, dict[str, Any]] = {
             "sndr.engines.vllm.patches.spec_decode."
             "pn133_mtp_scheduler_empty_output"
         ),
-        "lifecycle": "experimental",
+        "vllm_version_range": "<0.23.0",  # top-level cap for retired_provenance
+        # RETIRED 2026-07-05 (baseline-waiver drive-to-zero, by-code verify).
+        # vllm#42722's accounting fix is NATIVE in pristine dev748
+        # (scheduler.py:1585-1593): the `max(len(generated_token_ids) -
+        # num_sampled, 0)` clamp + the `or self.num_sampled_tokens_per_step
+        # == 0` empty-output disjunct make the len([])-1=-1 Prometheus crash
+        # and the permanently-stuck request both structurally impossible. The
+        # pre-fix anchor PN133_OLD is GONE (grep count 0); apply() already
+        # self-retires via the `max(len(generated_token_ids) - ` drift marker.
+        # Anchor GONE -> cap kept <0.23.0, NOT bumped. The env flag stays set
+        # in the 27B/35B YAMLs as a self-retiring no-op for <0.23.0 rollback.
+        "lifecycle": "retired",
+        "superseded_by": (
+            "vllm#42722 accounting fix native on dev748 "
+            "(0.23.1rc1.dev748+g2dfaae752): pristine scheduler.py:1585-1593 = "
+            "`if scheduled_spec_token_ids and (generated_token_ids or "
+            "self.num_sampled_tokens_per_step == 0):` with "
+            "`num_accepted = max(len(generated_token_ids) - num_sampled, 0)`. "
+            "Empty-output stuck-request bug and len([])-1 Prometheus crash "
+            "both impossible. PN133_OLD anchor absent (grep 0); apply() "
+            "self-retires via the `max(len(generated_token_ids) - ` drift "
+            "marker. Verified by code on pristine dev748 2026-07-05."
+        ),
         "experimental_note": (
             "Backport vllm#42722 (OPEN). Fixes permanently-stuck request "
             "in MTP/spec-decode when model_runner returns empty "
@@ -2498,7 +2520,21 @@ PATCH_REGISTRY: dict[str, dict[str, Any]] = {
                 "Qwen3MoeForCausalLM",
             ],
             # Valid for pins where MambaModelConfig.verify_and_update_config exists.
-            "vllm_version_range": (">=0.20.0", "<0.22.0"),
+            # 2026-07-05 dev748 reverify: anchor PRESENT+APPLICABLE on
+            # 0.23.1rc1.dev748+g2dfaae752 — Qwen3_5ForConditionalGenerationConfig
+            # (config.py:736) still ONLY sets mamba_ssm_cache_dtype (does NOT call
+            # MambaModelConfig natively), MambaModelConfig.verify_and_update_config
+            # (config.py:537) exists, and MODELS_CONFIG_MAP routes both our arches
+            # to it (config.py:837-838) — all confirmed live via
+            # `docker run --rm nightly-2dfaae752`. apply() both guards pass ->
+            # returns "applied". The FULL_AND_PIECEWISE effect stays redundant with
+            # the v1 resolver (compilation.py:1355-1357 still sets it under
+            # splitting_ops_contain_attention), so PN125 is a harmless upstream-
+            # bypass safety net — deliberately kept ON in 4 builtin YAMLs. Bumped
+            # <0.22.0 -> <0.24.0 so the insurance actually INSTALLS on dev748
+            # instead of being version-gate-skipped. Anchor present => BUMP, not
+            # RETIRE.
+            "vllm_version_range": (">=0.20.0", "<0.24.0"),
         },
     },
     "PN96b": {
@@ -4729,7 +4765,24 @@ PATCH_REGISTRY: dict[str, dict[str, Any]] = {
         "conflicts_with": [],
         "requires_patches": [],
         "apply_module": "sndr.engines.vllm.patches.attention.gdn.pn30_ds_layout_spec_decode_align",
-        "lifecycle": "experimental",
+        "vllm_version_range": "<0.23.0",
+        "superseded_by": (
+            "upstream fused-postprocess kernel — get_conv_copy_spec was "
+            "rewritten so the NotImplementedError this patch anchored on is "
+            "GONE, replaced by `assert offset == 0, \"...must be handled by "
+            "the fused postprocess kernel, not get_conv_copy_spec\"`. Native "
+            "handling of DS conv state + num_accepted_tokens > 1 is a superset "
+            "of PN30's memcpy workaround. Re-verified live on pristine dev748 "
+            "(2dfaae752) 2026-07-05: part1 anchor absent — "
+            "mamba_utils.py:305-310 carries the assert form, not the raise."
+        ),
+        # RETIRED 2026-07-05: superseded on the whole >=0.23.0 pin set (part1
+        # anchor GONE on dev748, re-verified by code). The cap <0.23.0 keeps
+        # PN30 correct on any <0.23.0 rollback (dev259/dev491 still raise the
+        # NotImplementedError). retired lifecycle auto-excludes PN30 from the
+        # stale-range audit, so its _BASELINE_CRITICAL_STALE waiver is removed
+        # in the same change (P64/P61b/PN287 retire precedent, 2026-07-03).
+        "lifecycle": "retired",
         "implementation_status": "full",
     },
     "P67c": {
@@ -6748,7 +6801,27 @@ PATCH_REGISTRY: dict[str, dict[str, Any]] = {
         "env_flag": "GENESIS_ENABLE_PN347",
         "default_on": False,
         "apply_module": "sndr.engines.vllm.patches.quantization.marlin.pn347_marlin_fp8_nk_correctness",
-        "lifecycle": "experimental",
+        "vllm_version_range": "<0.22.1rc1.dev491",  # top-level cap for retired_provenance
+        # RETIRED 2026-07-05: native/superseded on dev491+. Verified BY CODE on
+        # pristine dev748 (2dfaae752): kernels/linear/scaled_mm/marlin.py
+        # process_weights_after_loading was refactored to the size_k_first
+        # caller contract ("Non-block: callers must pass weight in (K,N)
+        # layout"); the buggy `if w_q.shape != (in,out)` transpose guard AND
+        # `_get_layer_params` are GONE (grep count 0), so the anchor is
+        # correctly absent and the N==K corruption cannot occur. Both live pins
+        # (current dev748, rollback dev714) are >> dev491, so PN347 is inert on
+        # every live pin. Anchor GONE -> cap kept <0.22.1rc1.dev491, NOT bumped.
+        "lifecycle": "retired",
+        "superseded_by": (
+            "vllm#44735 (structural size_k_first caller-contract refactor "
+            "landed 0.22.1rc1.dev491+): process_weights_after_loading moves the "
+            "transpose decision to the caller and DELETES the buggy "
+            "`w_q.shape != (...)` guard, so the square-matrix (N==K) corruption "
+            "PN347 fixes cannot occur. Verified by code on pristine dev748 "
+            "2026-07-05 (guard + _get_layer_params absent). The vendored PR "
+            "vllm#44113 was CLOSED-unmerged because upstream solved it "
+            "structurally."
+        ),
         "category": "correctness",
         "credit": (
             "Genesis vendoring of OPEN upstream PR vllm#44113 (shernshiou, "
@@ -7290,7 +7363,26 @@ PATCH_REGISTRY: dict[str, dict[str, Any]] = {
         "implementation_status": "full",
         "source": "genesis_original",
         "apply_module": "sndr.engines.vllm.patches.tool_parsing.pn374_qwen3xml_quoted_keys",
-        "lifecycle": "experimental",
+        "vllm_version_range": "<0.23.0",  # top-level cap for retired_provenance
+        # RETIRED 2026-07-05 (lifecycle=retired): #45588 engine rewrite DELETED
+        # tool_parsers/qwen3xml_tool_parser.py; both PN374 anchors are GONE on
+        # pristine dev748 (verified by code, 2dfaae752) and the native
+        # vllm/parser/qwen3.py json.dumps(params, ensure_ascii=False) path
+        # escapes BOTH keys and values, so the quoted-key corruption is
+        # structurally impossible. Anchor GONE -> cap kept <0.23.0, NOT bumped
+        # (still applies on the dev259 rollback pin where the old file exists).
+        "lifecycle": "retired",
+        "superseded_by": (
+            "vllm#45588 (streaming parser-engine refactor) DELETED "
+            "tool_parsers/qwen3xml_tool_parser.py; qwen3_xml now routes to "
+            "Qwen3EngineToolParser -> Qwen3ParserToolAdapter and the native "
+            "vllm/parser/qwen3.py serializes tool-call arguments via "
+            "json.dumps(params, ensure_ascii=False), escaping keys AND values. "
+            "A model-emitted quoted key yields valid JSON with the parameter "
+            "PRESENT, so neither PN374 harm mode (expat parse failure -> param "
+            "dropped; unescaped key interpolation -> invalid JSON) can occur. "
+            "Both anchors GONE on pristine dev748 (verified by code 2026-07-05)."
+        ),
         "credit": (
             "Genesis-original 2026-06-11 (50-PR sweep chunk-4 Theme 1 "
             "audit mandate). qwen3xml has the same key/value asymmetry "
@@ -7319,10 +7411,12 @@ PATCH_REGISTRY: dict[str, dict[str, Any]] = {
             "tool_call_parser": ["qwen3_xml"],
             # Registry-integration 2026-06-11: pin-specific text-patch
             # vendor — anchors byte-verified on the 0.22.1 pin only.
-        # 2026-06-17 (0.23.1 reverify): kept capped <0.23.0. The qwen3xml
-        # quoted-keys bug is GONE on 0.23.x (fixed upstream); anchors no
-        # longer exist. Do NOT bump (would re-arm a superseded patch).
-        # Patch + 15 tests retained for rollback contingency.
+        # 2026-07-05 RETIRED (lifecycle=retired): #45588 engine rewrite DELETED
+        # qwen3xml_tool_parser.py; both PN374 anchors are GONE on pristine
+        # dev748 and the native vllm/parser/qwen3.py json.dumps path makes the
+        # quoted-key corruption structurally impossible (see superseded_by).
+        # Cap kept <0.23.0 so the patch still applies on the dev259 rollback
+        # pin (old file present). Do NOT bump. Patch + 15 tests retained.
             "vllm_version_range": (">=0.22.0", "<0.23.0"),
         },
     },
@@ -8152,7 +8246,7 @@ PATCH_REGISTRY: dict[str, dict[str, Any]] = {
         "tier": "community",
         "family": "kv_cache",
         "env_flag": "GENESIS_ENABLE_PN110",
-        "default_on": True,
+        "default_on": False,
         "category": "stability",
         "credit": (
             "Backport of vllm#42615 (AkCodes23, OPEN 2026-05-14). "
@@ -8173,10 +8267,38 @@ PATCH_REGISTRY: dict[str, dict[str, Any]] = {
         # honest registry (not silently drift-skipped); re-anchor only if
         # KV-offloading is ever adopted.
         "applies_to": {"vllm_version_range": (">=0.20.0", "<0.23.0")},
+        "superseded_by": (
+            "vllm free_blocks LRU-split refactor (block_pool.py) — the "
+            "target region PN110 anchored on (`blocks_list = "
+            "list(ordered_blocks)` + the `for block in blocks_list: "
+            "block.ref_cnt -= 1` loop, preceded by the `# Materialize the "
+            "iterable` comment) is GONE on 0.23.1 dev748+g2dfaae752. "
+            "free_blocks now iterates ordered_blocks once, decrements "
+            "inline, and splits into blocks_with_hash / blocks_without_hash "
+            "guarded per-block by `if block.ref_cnt == 0 and not "
+            "block.is_null` before prepend_n/append_n. That guard "
+            "STRUCTURALLY prevents the double-APPEND PN110 defends against: "
+            "a duplicate block decrements 1->0 (appended once) then 0->-1 "
+            "(guard False, not re-appended), so the same KVCacheBlock can "
+            "no longer land in the free queue twice and the "
+            "fake_free_list_tail trip cannot occur. Verified live in the "
+            "pristine dev748 tree (block_pool.py:614 free_blocks; anchor "
+            "strings 0 matches) 2026-07-05."
+        ),
         "implementation_status": "full",
         "apply_module": "sndr.engines.vllm.patches.kv_cache.pn110_block_pool_free_dedup",
+        "vllm_version_range": "<0.23.0",  # top-level cap for retired_provenance
         "source": "vllm_pr_backport",
-        "lifecycle": "experimental",
+        # RETIRED 2026-07-05 (baseline-waiver drive-to-zero, by-code verify):
+        # anchor GONE on the whole deployable >=0.23.x pin set and the
+        # double-append symptom is natively guarded (see superseded_by).
+        # #42615 still OPEN and only reachable via SimpleCPUOffload, which
+        # Genesis PROD does not run. Cap <0.23.0 retained so a rollback pin
+        # (<0.23.0, where the old shape + anchor still exist) keeps the
+        # defensive guard via explicit YAML enable; on 0.23.x it is inert.
+        # Removed from _BASELINE_CRITICAL_STALE — retired lifecycle is
+        # auto-excluded from the stale-range audit.
+        "lifecycle": "retired",
     },
     "PN111": {
         "title": "Skip-mamba-postprocess GPU->CPU sync (align-mode; vllm#42574)",
@@ -9518,7 +9640,23 @@ PATCH_REGISTRY: dict[str, dict[str, Any]] = {
         "env_flag": "GENESIS_ENABLE_P29_QWEN3CODER_INDEX_HEAL",
         "default_on": False,
         "apply_module": "sndr.engines.vllm.patches.tool_parsing.p29_qwen3coder_index_heal",
-        "lifecycle": "experimental",
+        "vllm_version_range": "<0.22.1rc1.dev491",  # top-level cap for retired_provenance
+        # RETIRED 2026-07-05: anchor GONE on dev748. #45588 parser-engine
+        # refactor DELETED tool_parsers/qwen3coder_tool_parser.py (the P29_HEAL
+        # target); the engine-native Qwen3EngineToolParser adapter has no
+        # streamed_args_for_tool/current_tool_index list state, so the
+        # IndexError class P29_HEAL healed is structurally absent. Same
+        # retirement as siblings P64/P61c/PN56. Cap kept <0.22.1rc1.dev491
+        # (still excludes dev748) — do NOT bump a range whose anchor is gone.
+        "lifecycle": "retired",
+        "superseded_by": (
+            "vllm#45413/#45171/#45588 (streaming parser-engine refactor) — "
+            "tool_parsers/qwen3coder_tool_parser.py DELETED; "
+            "Qwen3EngineToolParser (vllm.parser.engine) owns streaming with no "
+            "list-indexed tool-arg state. Target file + both anchor sites "
+            "(287/442) absent on pristine dev748 (verified by code 2026-07-05, "
+            "2dfaae752)."
+        ),
         "category": "structured_output",
         "credit": (
             "Genesis-original 2026-06-04 — extends P29's coverage. "
@@ -9823,14 +9961,28 @@ PATCH_REGISTRY: dict[str, dict[str, Any]] = {
         "credit": "Backport of vllm#41696 (panpan0000, OPEN as of 2026-05-05). Removes the buggy `prompt_reasoning_checked` short-circuit in `vllm.parser.abstract_parser.DelegatingParser.parse_delta` that walked the FULL prompt looking for `</think>` and prematurely set `reasoning_ended=True` from a previous turn's `</think>`. Defensive backport for multi-turn DSML/Hermes/Qwen3 chat clients sending full history. Original report: DeepSeek V3.2 reasoning users.",
         "upstream_pr": 41696,
         "upstream_pr_relationship": "backport",
-        # 2026-06-18 (dev148 full-patch audit): #45588 reorganized the parser
-        # into vllm/parser/abstract_parser.py — PN66's DelegatingParser anchor
-        # is gone (DRIFT skip on 0.23.x). A LIVE multiturn-reasoning probe on
-        # dev148 showed NO </think> leak (the new engine parser handles the
-        # reasoning+tool compose), and #41696 is CLOSED-unmerged. Capped
-        # <0.23.0 so the registry is honest (correctly inert, not silently
-        # drift-skipped). Re-anchor to the new parser only if a </think> leak
-        # is ever observed live on 0.23.x+.
+        # 2026-06-18 (dev148) / re-verified BY CODE on dev748 2026-07-05
+        # (pristine /tmp/pristine_dev748_2dfaae752): the #45413/#45588
+        # parser-engine refactor did NOT delete abstract_parser.py.
+        # DelegatingParser (line 371), the `prompt_reasoning_checked` field
+        # (line 50) and PN66's FIELD anchor are all PRESENT — so the earlier
+        # "DelegatingParser anchor is gone" note was inaccurate. What actually
+        # happened: PN66's BLOCK anchor DRIFTED — upstream KEPT the prompt-scan
+        # block (lines 805-816) but added an `else:` branch calling
+        # `adjust_initial_state_from_prompt` and switched to `state.advance(...)`,
+        # so the required block sub-patch no longer byte-matches → PN66 cannot
+        # apply on 0.23.x. The multiturn </think> leak is NATIVE-FIXED:
+        # parser_engine.is_reasoning_end (engine/parser_engine.py:581) now scans
+        # backward and returns False on hitting `<think>` (start_id) before
+        # `</think>` (end_id) — exactly the guard the old buggy prompt-scan
+        # lacked. #41696 is CLOSED-unmerged (upstream solved it structurally, not
+        # by removing the block, so a byte-exact re-anchor of PN66 would DELETE
+        # correct upstream behavior — do NOT bump the bound). Capped <0.23.0
+        # because PN66 still applies+fixes the leak on rollback pins <0.23.0
+        # (whose is_reasoning_end had no start_id guard) and stays enabled in the
+        # qwen3.6 27B/35B builtin YAMLs for exactly that rollback protection — a
+        # DELIBERATE cross-pin gate (same class as PN30/PN51/PN133), not
+        # debt-to-bump. Re-anchor only if a </think> leak is ever seen on 0.23.x+.
         "applies_to": {"vllm_version_range": (">=0.20.0", "<0.23.0")},
         "apply_module": "sndr.engines.vllm.patches.reasoning.pn66_multiturn_think_leak",
         "lifecycle": "experimental",
@@ -10242,13 +10394,36 @@ PATCH_REGISTRY: dict[str, dict[str, Any]] = {
         "tier": "community",
         "family": "gemma4",
         "env_flag": "GENESIS_ENABLE_G4_14_GEMMA4_TOOL_CALL_PARSER_PAD",
-        "default_on": True,
+        "default_on": False,
         "category": "stability",
         "implementation_status": "full",
         "source": "genesis_original",
         "apply_module": "sndr.engines.vllm.patches.model_compat.gemma4.g4_14_gemma4_tool_call_parser_pad_token",
-        "lifecycle": "stable",
-        "stable_kind": "runtime-hook",
+        "vllm_version_range": "<0.23.0",  # top-level cap for retired_provenance
+        # RETIRED 2026-07-05 (lifecycle=retired, default_on=False): verified BY
+        # CODE on pristine dev748 (2dfaae752) — the class G4_14 wraps,
+        # Gemma4ToolParser, is DELETED by the #45588 tool-parser reorg. The only
+        # surviving class is Gemma4EngineToolParser
+        # (vllm/tool_parsers/gemma4_engine_tool_parser.py:14) which decodes with
+        # skip_special_tokens=False (line 34) and extracts via the structured
+        # vllm/parser/gemma4.py:392 pass, so the #39392 raw-token pad-leak mode
+        # no longer exists. G4_14._find_gemma_tool_parser() targets only the
+        # deleted names -> returns None -> apply() graceful-skips even with the
+        # flag forced on. Anchor GONE -> cap kept <0.23.0, NOT bumped. #39392
+        # still OPEN: redesign vs Gemma4EngineToolParser with a failing repro
+        # test before lifting the cap. Cap retained so a <0.23.0 rollback pin
+        # keeps the pad-strip via explicit gemma YAML enable.
+        "lifecycle": "retired",
+        "superseded_by": (
+            "vllm#45588 tool-parser reorg DELETED Gemma4ToolParser (the class "
+            "G4_14 wraps). The replacement Gemma4EngineToolParser "
+            "(vllm/tool_parsers/gemma4_engine_tool_parser.py) decodes with "
+            "skip_special_tokens=False and parses fully-decoded text via "
+            "vllm/parser/gemma4.py, so the #39392 raw-token pad-leak mode is "
+            "structurally gone. Verified by code on pristine dev748 "
+            "(2dfaae752) 2026-07-05: _find_gemma_tool_parser() targets only the "
+            "deleted names -> None -> apply() graceful-skips. #39392 still OPEN."
+        ),
         "production_validated_pins": [
             ("v12.0.0", "0.20.2rc1.dev338+gbf0d2dc6d"),
             ("v12.0.0", "0.20.2rc1.dev371+gbf610c2f5"),
@@ -11345,7 +11520,24 @@ PATCH_REGISTRY: dict[str, dict[str, Any]] = {
         "implementation_status": "full",
         "source": "vllm_pr_backport",
         "apply_module": "sndr.engines.vllm.patches.spec_decode.pn378_recovered_token_vocab_pad_mask",
-        "lifecycle": "experimental",
+        # RETIRED 2026-07-05 (lifecycle=retired): the complete vllm#45060
+        # (mask + OOV clamp) is native in pristine dev748 (2dfaae752)
+        # rejection_sampler.py L945/L952; the dev259 splice anchor
+        # PN378_MASK_OLD is GONE (count 0). Anchor GONE -> cap kept <0.23.0,
+        # NOT bumped (still valid on the dev259 rollback base). PN378 already
+        # Layer-3 self-skips (upstream_merged) on dev491+ via its drift markers.
+        "lifecycle": "retired",
+        "superseded_by": (
+            "vllm#45060 (kernel mask half + OOV clamp) MERGED upstream by "
+            "0.22.1rc1.dev491+g1033ffac2 and ships COMPLETE in the live 0.23.1 "
+            "pins. Pristine dev748 (2dfaae752) verification 2026-07-05 — "
+            "v1/sample/rejection_sampler.py native: L945 "
+            "`score = tl.where(vocab_mask, score, float(\"-inf\"))` (the mask "
+            "half PN378 vendored) + L952 "
+            "`recovered_id = tl.minimum(recovered_id, vocab_size - 1)` (OOV "
+            "clamp). The dev259 splice anchor PN378_MASK_OLD is GONE (count 0). "
+            "Cap kept <0.23.0: still valid on the dev259 rollback base."
+        ),
         "credit": (
             "PR-sweep wave 2 (2026-06-13). Vendor of OPEN vllm#45060 "
             "(KERNEL HALF only; root cause of #26372/#33729/#42722): "

--- a/sndr/engines/vllm/patches/attention/gdn/pn30_ds_layout_spec_decode_align.py
+++ b/sndr/engines/vllm/patches/attention/gdn/pn30_ds_layout_spec_decode_align.py
@@ -1,6 +1,17 @@
 # SPDX-License-Identifier: Apache-2.0
 """Wiring for Patch N30 — DS conv state layout + spec-decode AL>1 fix.
 
+RETIRED 2026-07-05 (lifecycle: retired, capped <0.23.0): superseded by the
+upstream fused-postprocess kernel. `get_conv_copy_spec` was rewritten so the
+part1 anchor — the `NotImplementedError` raise for DS + num_accepted_tokens>1
+— is GONE; the current form is `assert offset == 0, "...must be handled by the
+fused postprocess kernel, not get_conv_copy_spec"` (re-verified by code on
+pristine dev748 / 2dfaae752, mamba_utils.py:305-310). Native DS-conv +
+spec-decode AL>1 handling is a superset of this memcpy workaround. The module
+is kept (not deleted) because the <0.23.0 cap still applies it on a dev259 /
+dev491 rollback where the NotImplementedError path is live. On the deployed
+>=0.23.0 pin set the version gate skips all three parts.
+
 ================================================================
 Issue
 ================================================================

--- a/sndr/engines/vllm/patches/kv_cache/pn110_block_pool_free_dedup.py
+++ b/sndr/engines/vllm/patches/kv_cache/pn110_block_pool_free_dedup.py
@@ -76,12 +76,12 @@ from __future__ import annotations
 import logging
 import os
 
+from sndr.engines.vllm.detection.guards import resolve_vllm_file, vllm_install_root
 from sndr.kernel import (
     TextPatch,
     TextPatcher,
     TextPatchResult,
 )
-from sndr.engines.vllm.detection.guards import resolve_vllm_file, vllm_install_root
 
 log = logging.getLogger("genesis.wiring.pn110_block_pool_free_dedup")
 
@@ -162,7 +162,7 @@ def _make_patcher() -> TextPatcher | None:
     )
 
 
-def apply() -> tuple[str, str]:
+def apply() -> tuple[str, str]:  # noqa: PLR0911 - dispatcher early-return cascade: distinct skip/self-retire reasons per gate
     """Apply PN110 — BlockPool.free_blocks deduplication."""
     from sndr.dispatcher import log_decision, should_apply
 

--- a/sndr/engines/vllm/patches/kv_cache/pn110_block_pool_free_dedup.py
+++ b/sndr/engines/vllm/patches/kv_cache/pn110_block_pool_free_dedup.py
@@ -1,6 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 """Wiring for Patch PN110 — BlockPool.free_blocks deduplication.
 
+RETIRED 2026-07-05 (lifecycle: retired, cap kept <0.23.0): the free_blocks
+region PN110 anchored on is GONE on pristine dev748 (LRU-split rewrite; the
+per-block ``if block.ref_cnt == 0`` append-guard structurally prevents the
+double-append symptom). Superseded on the whole >=0.23.0 pin set; still applies
+on a <0.23.0 rollback pin via explicit YAML enable.
+
 Backport of [vllm#42615](https://github.com/vllm-project/vllm/pull/42615)
 by `AkCodes23` (OPEN at the time of backport).
 

--- a/sndr/engines/vllm/patches/model_compat/gemma4/g4_14_gemma4_tool_call_parser_pad_token.py
+++ b/sndr/engines/vllm/patches/model_compat/gemma4/g4_14_gemma4_tool_call_parser_pad_token.py
@@ -1,6 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 """G4_14 — Gemma 4 tool-call parser pad-token workaround (closes vllm#39392).
 
+RETIRED 2026-07-05 (lifecycle: retired, default_on=False, cap kept <0.23.0):
+Gemma4ToolParser (the class this patch wraps) is DELETED by #45588; the
+surviving Gemma4EngineToolParser decodes skip_special_tokens=False so the
+#39392 raw-token pad-leak mode is gone. Anchor GONE on pristine dev748 ->
+_find_gemma_tool_parser() misses -> graceful no-op. Still applies on a <0.23.0
+rollback pin via explicit gemma YAML enable. #39392 still OPEN.
+
 ================================================================
 WHAT IT FIXES
 ================================================================

--- a/sndr/engines/vllm/patches/model_compat/gemma4/g4_14_gemma4_tool_call_parser_pad_token.py
+++ b/sndr/engines/vllm/patches/model_compat/gemma4/g4_14_gemma4_tool_call_parser_pad_token.py
@@ -131,7 +131,7 @@ def _find_gemma_tool_parser():
 
 def apply() -> tuple[str, str]:
     """Install pad-token strip wrappers on Gemma4ToolParser methods."""
-    global _APPLIED, _ORIGINAL_STREAMING, _ORIGINAL_BATCH, _PATCHED_CLS
+    global _APPLIED, _ORIGINAL_STREAMING, _ORIGINAL_BATCH, _PATCHED_CLS  # noqa: PLW0603 - module-level idempotency latch, same pattern as sibling patch modules
 
     if not _env_enabled():
         return "skipped", (
@@ -192,7 +192,7 @@ def is_applied() -> bool:
 
 
 def revert() -> bool:
-    global _APPLIED, _ORIGINAL_STREAMING, _ORIGINAL_BATCH, _PATCHED_CLS
+    global _APPLIED, _ORIGINAL_STREAMING, _ORIGINAL_BATCH, _PATCHED_CLS  # noqa: PLW0603 - module-level idempotency latch, same pattern as sibling patch modules
     if not _APPLIED or _PATCHED_CLS is None:
         return False
     if _ORIGINAL_STREAMING is not None:

--- a/sndr/engines/vllm/patches/quantization/marlin/pn347_marlin_fp8_nk_correctness.py
+++ b/sndr/engines/vllm/patches/quantization/marlin/pn347_marlin_fp8_nk_correctness.py
@@ -240,7 +240,7 @@ def _make_patcher_for_drift() -> TextPatcher | None:
     )
 
 
-def apply() -> tuple[str, str]:
+def apply() -> tuple[str, str]:  # noqa: PLR0911 - dispatcher early-return cascade: distinct skip/self-retire reasons per gate
     """Apply PN347 — MarlinFP8 (N==K) correctness fix."""
     if _env_disabled():
         return "skipped", "PN347 disabled via GENESIS_DISABLE_PN347=1"

--- a/sndr/engines/vllm/patches/quantization/marlin/pn347_marlin_fp8_nk_correctness.py
+++ b/sndr/engines/vllm/patches/quantization/marlin/pn347_marlin_fp8_nk_correctness.py
@@ -1,6 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 """PN347 — vendor of OPEN PR vllm#44113 (shernshiou) MarlinFP8 N==K correctness.
 
+RETIRED 2026-07-05 (lifecycle: retired, cap kept <0.22.1rc1.dev491): superseded
+by vllm#44735's structural size_k_first caller-contract refactor at dev491+,
+which DELETED the buggy ``w_q.shape != (...)`` transpose guard (anchor GONE on
+pristine dev748). Both live pins are >> dev491 so PN347 is inert; still applies
+on a <dev491 rollback pin where the old guard exists.
+
 MarlinFP8 weight transpose silently skipped for square (N==K) matrices on sm_75-88
 =================================================================================
 

--- a/sndr/engines/vllm/patches/spec_decode/pn133_mtp_scheduler_empty_output.py
+++ b/sndr/engines/vllm/patches/spec_decode/pn133_mtp_scheduler_empty_output.py
@@ -1,6 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 """PN133 — MTP scheduler empty-output accounting fix (backport vllm#42722).
 
+RETIRED 2026-07-05 (lifecycle: retired, cap kept <0.23.0): vllm#42722's
+accounting fix is native on pristine dev748 (scheduler.py:1585-1593 — the
+``max(len(generated_token_ids) - num_sampled, 0)`` clamp + empty-output
+disjunct); the pre-fix anchor PN133_OLD is GONE (grep 0) so apply() self-skips.
+Still applies on a <0.23.0 rollback pin via explicit YAML enable.
+
 ================================================================
 PROBLEM
 ================================================================

--- a/sndr/engines/vllm/patches/spec_decode/pn133_mtp_scheduler_empty_output.py
+++ b/sndr/engines/vllm/patches/spec_decode/pn133_mtp_scheduler_empty_output.py
@@ -186,9 +186,9 @@ def _env_enabled() -> bool:
     return val in ("1", "true", "yes", "on")
 
 
-def apply() -> tuple[str, str]:
+def apply() -> tuple[str, str]:  # noqa: PLR0911 - dispatcher early-return cascade: distinct skip/self-retire reasons per gate
     """Text-patch on scheduler.py — fix empty generated_token_ids accounting."""
-    global _APPLIED
+    global _APPLIED  # noqa: PLW0603 - module-level idempotency latch, same pattern as sibling patch modules
 
     if not _env_enabled():
         return "skipped", (
@@ -202,7 +202,7 @@ def apply() -> tuple[str, str]:
 
     try:
         from sndr.engines.vllm.detection.guards import resolve_vllm_file
-        from sndr.kernel import TextPatcher, TextPatch
+        from sndr.kernel import TextPatch, TextPatcher
     except ImportError as e:
         return "skipped", f"genesis core not importable: {e}"
 

--- a/sndr/engines/vllm/patches/spec_decode/pn378_recovered_token_vocab_pad_mask.py
+++ b/sndr/engines/vllm/patches/spec_decode/pn378_recovered_token_vocab_pad_mask.py
@@ -1,6 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 """PN378 — recovered-token vocab-pad -inf mask (vendor of vllm#45060, kernel half).
 
+RETIRED 2026-07-05 (lifecycle: retired, cap kept <0.23.0): the complete
+vllm#45060 kernel fix (mask + OOV clamp) is native in pristine dev748
+(rejection_sampler.py L945/L952); the dev259 splice anchor PN378_MASK_OLD is
+GONE (count 0). PN378 already Layer-3 self-skips (upstream_merged) on dev491+.
+Still applies on the dev259 rollback base where the pre-fix kernel exists.
+
 Upstream bug class (vllm#45060, root cause of #26372 / #33729 / #42722):
 ``sample_recovered_tokens_kernel`` in ``v1/sample/rejection_sampler.py``
 tiles the vocab in ``BLOCK_SIZE`` chunks; the final tile's padding lanes

--- a/sndr/engines/vllm/patches/tool_parsing/pn374_qwen3xml_quoted_keys.py
+++ b/sndr/engines/vllm/patches/tool_parsing/pn374_qwen3xml_quoted_keys.py
@@ -1,6 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 """PN374 — qwen3xml quoted parameter-name (key) sanitization.
 
+RETIRED 2026-07-05 (lifecycle: retired, cap kept <0.23.0): #45588 DELETED
+tool_parsers/qwen3xml_tool_parser.py; both PN374 anchors are GONE on pristine
+dev748 and the native vllm/parser/qwen3.py json.dumps(..., ensure_ascii=False)
+path escapes keys AND values, so the quoted-key corruption is structurally
+impossible. Still applies on the dev259 rollback pin where the old file exists.
+
 Problem
 -------
 Roadmap 2026-06-11 (50-PR sweep, chunk 4 Theme 1) mandated an audit of

--- a/tests/unit/dispatcher/fixtures/decision_no_env.json
+++ b/tests/unit/dispatcher/fixtures/decision_no_env.json
@@ -937,7 +937,7 @@
   {
     "patch_id": "PN110",
     "applied": false,
-    "reason": "strict opt-in: patch has default_on=True (informational) but env_flag=GENESIS_ENABLE_PN110 unset. Add GENESIS_ENABLE_PN110=1 to launch config to engage. Set GENESIS_LEGACY_DEFAULT_ON=1 to revert to pre-2026-05-17 auto-apply semantics."
+    "reason": "strict opt-in — set GENESIS_ENABLE_PN110=1 in config to engage (GENESIS_LEGACY_DEFAULT_ON=1 reverts to pre-2026-05-17 semantics)"
   },
   {
     "patch_id": "PN111",
@@ -1337,7 +1337,7 @@
   {
     "patch_id": "G4_14",
     "applied": false,
-    "reason": "strict opt-in: patch has default_on=True (informational) but env_flag=GENESIS_ENABLE_G4_14_GEMMA4_TOOL_CALL_PARSER_PAD unset. Add GENESIS_ENABLE_G4_14_GEMMA4_TOOL_CALL_PARSER_PAD=1 to launch config to engage. Set GENESIS_LEGACY_DEFAULT_ON=1 to revert to pre-2026-05-17 auto-apply semantics."
+    "reason": "strict opt-in — set GENESIS_ENABLE_G4_14_GEMMA4_TOOL_CALL_PARSER_PAD=1 in config to engage (GENESIS_LEGACY_DEFAULT_ON=1 reverts to pre-2026-05-17 semantics)"
   },
   {
     "patch_id": "G4_15",

--- a/tests/unit/dispatcher/fixtures/spec_set.json
+++ b/tests/unit/dispatcher/fixtures/spec_set.json
@@ -734,7 +734,7 @@
   {
     "patch_id": "PN133",
     "family": "spec_decode",
-    "lifecycle": "experimental",
+    "lifecycle": "retired",
     "tier": "community",
     "default_on": false,
     "env_flag": "GENESIS_ENABLE_PN133_MTP_EMPTY_OUTPUT_FIX",
@@ -1370,7 +1370,7 @@
   {
     "patch_id": "PN30",
     "family": "attention.gdn",
-    "lifecycle": "experimental",
+    "lifecycle": "retired",
     "tier": "community",
     "default_on": false,
     "env_flag": "GENESIS_ENABLE_PN30_DS_LAYOUT_SPEC_DECODE",
@@ -1874,7 +1874,7 @@
   {
     "patch_id": "PN347",
     "family": "quantization.marlin",
-    "lifecycle": "experimental",
+    "lifecycle": "retired",
     "tier": "community",
     "default_on": false,
     "env_flag": "GENESIS_ENABLE_PN347",
@@ -1994,7 +1994,7 @@
   {
     "patch_id": "PN374",
     "family": "tool_parsing",
-    "lifecycle": "experimental",
+    "lifecycle": "retired",
     "tier": "community",
     "default_on": false,
     "env_flag": "GENESIS_ENABLE_PN374_QWEN3XML_QUOTED_KEYS",
@@ -2246,9 +2246,9 @@
   {
     "patch_id": "PN110",
     "family": "kv_cache",
-    "lifecycle": "experimental",
+    "lifecycle": "retired",
     "tier": "community",
-    "default_on": true,
+    "default_on": false,
     "env_flag": "GENESIS_ENABLE_PN110",
     "has_upstream_pr": true,
     "upstream_pr_relationship": "backport",
@@ -2786,7 +2786,7 @@
   {
     "patch_id": "P29_HEAL",
     "family": "tool_parsing",
-    "lifecycle": "experimental",
+    "lifecycle": "retired",
     "tier": "community",
     "default_on": false,
     "env_flag": "GENESIS_ENABLE_P29_QWEN3CODER_INDEX_HEAL",
@@ -3206,9 +3206,9 @@
   {
     "patch_id": "G4_14",
     "family": "gemma4",
-    "lifecycle": "stable",
+    "lifecycle": "retired",
     "tier": "community",
-    "default_on": true,
+    "default_on": false,
     "env_flag": "GENESIS_ENABLE_G4_14_GEMMA4_TOOL_CALL_PARSER_PAD",
     "has_upstream_pr": false,
     "upstream_pr_relationship": "backport",
@@ -3686,7 +3686,7 @@
   {
     "patch_id": "PN378",
     "family": "spec_decode",
-    "lifecycle": "experimental",
+    "lifecycle": "retired",
     "tier": "community",
     "default_on": false,
     "env_flag": "GENESIS_ENABLE_PN378_VOCAB_PAD_MASK",

--- a/tests/unit/dispatcher/test_version_gate.py
+++ b/tests/unit/dispatcher/test_version_gate.py
@@ -14,9 +14,10 @@ from __future__ import annotations
 
 import pytest
 
-from sndr.dispatcher import decision as D
 from sndr.compat import version_check as vc
-
+from sndr.dispatcher import (
+    decision as D,  # noqa: N812 - module alias used throughout this test
+)
 
 DEV259 = "0.22.1rc1.dev259+g303916e93"
 

--- a/tests/unit/dispatcher/test_version_gate.py
+++ b/tests/unit/dispatcher/test_version_gate.py
@@ -82,11 +82,14 @@ class TestShouldApplyIntegration:
     def test_enforced_version_mismatch_skips_even_when_env_enabled(
         self, engine_is_dev259, monkeypatch
     ):
-        # PN125 is a real registry patch; env-enable it, enforce versions.
-        monkeypatch.setenv("GENESIS_ENABLE_PN125_HYBRID_FULL_AND_PIECEWISE", "1")
+        # P77 is a real registry patch still capped ('>=0.20.0', '<0.22.0'),
+        # which excludes dev259 (0.22.1); env-enable it, enforce versions.
+        # (PN125 was bumped to <0.24.0 on 2026-07-05 after the dev748 reverify,
+        # so it no longer excludes dev259 and can't exercise this path.)
+        monkeypatch.setenv("GENESIS_ENABLE_P77_ADAPTIVE_NGRAM_K", "1")
         monkeypatch.setenv("GENESIS_ENFORCE_VERSION_RANGE", "1")
         monkeypatch.delenv("GENESIS_LEGACY_DEFAULT_ON", raising=False)
-        decision, reason = D.should_apply("PN125")
+        decision, reason = D.should_apply("P77")
         assert decision is False
         assert "VERSION-GATE" in reason
 
@@ -95,8 +98,8 @@ class TestShouldApplyIntegration:
     ):
         # Same patch, same pin, but enforcement OFF -> env-override wins
         # (proves the gate ships as a no-op by default).
-        monkeypatch.setenv("GENESIS_ENABLE_PN125_HYBRID_FULL_AND_PIECEWISE", "1")
+        monkeypatch.setenv("GENESIS_ENABLE_P77_ADAPTIVE_NGRAM_K", "1")
         monkeypatch.delenv("GENESIS_ENFORCE_VERSION_RANGE", raising=False)
         monkeypatch.delenv("GENESIS_LEGACY_DEFAULT_ON", raising=False)
-        decision, _ = D.should_apply("PN125")
+        decision, _ = D.should_apply("P77")
         assert decision is True


### PR DESCRIPTION
## Goal
Drive the `audit_stale_vllm_version_ranges` CRITICAL waiver (`_BASELINE_CRITICAL_STALE`) toward zero by re-adjudicating **every** entry BY CODE against the pristine dev748 tree (`0.23.1rc1.dev748+g2dfaae752`). Iron rule: **never bump a range for a patch whose anchor is GONE**.

## Result
Baseline shrinks **12 → 1**. The sole survivor is **PN66** (KEEP_WAIVER — target file survives, still applies on `<0.23.0` rollback, leak native-fixed on 0.23.x; neither BUMP nor RETIRE is correct).

## Per-patch verdicts applied
| Patch | Verdict | Anchor on dev748 | Action |
|---|---|---|---|
| PN66 | KEEP_WAIVER | partial (block drifted, native-fixed) | stays in baseline; comment tightened |
| G4_14 | CONFIRM_RETIRE | GONE (#45588 deleted Gemma4ToolParser) | stable→retired, default_on→False, cap kept |
| PN133 | CONFIRM_RETIRE | GONE (native scheduler.py:1585-1593) | →retired, cap kept |
| PN347 | CONFIRM_RETIRE | GONE (#44735 size_k_first refactor) | →retired, cap kept |
| PN378 | CONFIRM_RETIRE | GONE (native rejection_sampler L945/L952) | →retired, cap kept |
| PN374 | CONFIRM_RETIRE | GONE (#45588 deleted qwen3xml parser) | →retired, cap kept |
| P29_HEAL | CONFIRM_RETIRE | GONE (#45413/#45171/#45588) | →retired, cap kept |
| PN362/PN370/PN383 | CONFIRM_RETIRE | native | already retired; removed dead waiver row |
| P61c | CONFIRM_RETIRE | GONE | orphan alias of retired P64; row removed |
| PN90 | ALREADY_CLEAN | self-skips | WARN not CRITICAL; kept experimental (test-locked), row removed |

No range was bumped for any GONE anchor. Caps retained so patches stay correct on `<0.23.0` rollback pins.

## Wiring / gates
- `retired_provenance`: added `superseded_by` + top-level `vllm_version_range` to the 6 newly-retired entries (PN110 too).
- v2 patch-lifecycle allowlist: PN30/PN110/G4_14/PN133 kept enabled in model YAMLs as rollback insurance (self-skip on the deployed pin), matching the PN82/P64/PN287 precedent.
- RETIRED docstring markers on the 6 patch modules.
- Regenerated `spec_set.json` + `decision_no_env.json` snapshots and `docs/PATCHES_AUTO.md` + curated lifecycle table (retired 52→60, experimental 228→221, stable 14→13).

## Verification
- `audit_stale_vllm_version_ranges.py --strict` → exit 0, CRITICAL={PN66} ⊆ baseline
- registry-contract, v2-lifecycle, doc-sync, docstring-sync, generated-links → green
- dispatcher + scripts + apply-sync + affected family/patch suites → green
- 0-new-ruff (remaining ruff findings pre-exist on `main`)