### PR TITLE
fix(daemon): engine key + persistent pgvector memory in compose + launcher

### DIFF
--- a/compose/docker-compose.full.yml
+++ b/compose/docker-compose.full.yml
@@ -77,6 +77,7 @@ services:
     restart: unless-stopped
     depends_on:
       - vllm-engine
+      - memory-db
     ports:
       # One port serves the bundled web UI AND the Product API (8765).
       - "8765:8765"
@@ -87,25 +88,56 @@ services:
       SNDR_ENABLE_APPLY: "${SNDR_ENABLE_APPLY:-}"
       # Point the daemon's engine client at the engine service on the shared net.
       SNDR_RUNTIME_HOST: vllm-engine
+      # Engine detect needs the URL AND the key — the engine rejects keyless
+      # /v1/models with 401, which the daemon reads as "no engine" and falls
+      # back to an empty :8000 (root-caused 2026-07-06). Default matches the
+      # engine service's api-key below.
+      SNDR_OPENAI_BASE_URL: "http://vllm-engine:8000/v1"
+      SNDR_ENGINE_API_KEY: "${SNDR_ENGINE_API_KEY:-genesis-local}"
+      # Persistent neural-graph memory -> the pgvector service below. Unset ->
+      # ephemeral in-memory store (empties on every restart -> GUI "Memory:
+      # Error Not Found"). dim 256 matches the default hash embedder + schema.
+      GENESIS_MEMORY_DSN: "postgresql://genesis:genesis_mem_dev@memory-db:5432/genesis_memory"
+      GENESIS_MEMORY_EMBEDDER: "${GENESIS_MEMORY_EMBEDDER:-hash}"
+      GENESIS_MEMORY_DIM: "${GENESIS_MEMORY_DIM:-256}"
+    # `psycopg` is NOT in the vLLM base image, so PostgresStore would fail its
+    # import and silently fall back to in-memory. Install it at boot, then run
+    # the SAME run_server the CLI path uses (so compose + CLI cannot drift).
     entrypoint:
-      - python3
+      - sh
       - -c
-      # Launch the Product API server directly — the SAME run_server the
-      # `gui-api` CLI path calls (sndr.product_api.legacy.http_app), so the CLI
-      # and the compose bring-up cannot drift.
       - >-
-        import os;
+        pip install --quiet "psycopg[binary]>=3.1" 2>&1 | tail -1;
+        exec python3 -c "import os;
         from sndr.product_api.legacy.http_app import run_server;
         run_server(host=os.environ.get('SNDR_BIND', '0.0.0.0'),
         port=int(os.environ.get('SNDR_GUI_PORT') or 8765),
         enable_apply=os.environ.get('SNDR_ENABLE_APPLY', '').strip().lower()
-        in ('1', 'true', 'yes', 'on'))
+        in ('1', 'true', 'yes', 'on'))"
     volumes:
       # Re-mount the canonical sndr/ package so the daemon resolves `import sndr`.
       - "${SNDR_SRC_DIR:-../sndr}:/usr/local/lib/python3.12/dist-packages/sndr:ro"
     networks:
       - sndr-net
 
+  # Persistent memory backend (pgvector). Without it the GUI Memory tab shows
+  # data only for the current daemon lifetime.
+  memory-db:
+    image: "pgvector/pgvector:0.8.0-pg15"
+    container_name: genesis-memory-db
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: genesis
+      POSTGRES_PASSWORD: genesis_mem_dev
+      POSTGRES_DB: genesis_memory
+    volumes:
+      - "sndr-memory-data:/var/lib/postgresql/data"
+    networks:
+      - sndr-net
+
 networks:
   sndr-net:
     driver: bridge
+
+volumes:
+  sndr-memory-data:

--- a/docs/GUI.md
+++ b/docs/GUI.md
@@ -444,3 +444,25 @@ all in this repo:
 - `docs/GUI_SECURITY.md` — bind, auth (accounts/2FA/OAuth/PAM), persistence,
   redaction, and dangerous-action policy.
 - `gui/web/README.md` — frontend architecture (tech stack, layout, i18n, dev/build).
+
+## Daemon configuration — engine detection & persistent memory
+
+The GUI daemon (`sndr-daemon`, port **8765**) needs two pieces of config or it
+silently degrades:
+
+1. **Engine detection.** The daemon probes the engine's `/v1/models`; the engine
+   rejects keyless requests with `401`, which the daemon reads as "no engine"
+   and falls back to an empty `:8000`. Pass the engine URL **and** key:
+   `SNDR_OPENAI_BASE_URL` + `SNDR_ENGINE_API_KEY` (matching the engine's
+   `--api-key`).
+2. **Persistent memory.** Memory uses `GENESIS_MEMORY_DSN` → a pgvector Postgres
+   (`genesis-memory-db`, dim 256 = default hash embedder). Unset → an ephemeral
+   in-memory store that empties on every restart (surfaces as **Memory: Error
+   Not Found**). `psycopg` is **not** in the vLLM base image, so the daemon
+   pip-installs `psycopg[binary]>=3.1` at boot before starting.
+
+`compose/docker-compose.full.yml` wires all of this (engine key, memory DSN,
+`memory-db` service, psycopg install). For a single-host / rig deployment use
+`scripts/start_sndr_daemon.sh`. A guard test
+(`tests/unit/compose/test_daemon_engine_memory_wiring.py`) keeps the compose
+from regressing.

--- a/scripts/start_sndr_daemon.sh
+++ b/scripts/start_sndr_daemon.sh
@@ -12,7 +12,9 @@ set -euo pipefail
 ENGINE_URL="${SNDR_OPENAI_BASE_URL:-http://127.0.0.1:8102/v1}"
 ENGINE_KEY="${SNDR_ENGINE_API_KEY:-genesis-local}"
 MEM_DSN="${GENESIS_MEMORY_DSN:-postgresql://genesis:genesis_mem_dev@127.0.0.1:55432/genesis_memory}"
-SNDR_SRC="${SNDR_SRC_DIR:-/home/sander/gvp-mainsync/sndr}"
+# Path to the canonical sndr/ package dir (e.g. <your-repo>/sndr or the
+# rig sync tree). Required — no operator-specific default is baked in.
+SNDR_SRC="${SNDR_SRC_DIR:?set SNDR_SRC_DIR to the sndr package directory}"
 IMAGE="${SNDR_DAEMON_IMAGE:-vllm/vllm-openai:nightly}"
 docker rm -f sndr-daemon >/dev/null 2>&1 || true
 docker run -d --name sndr-daemon --network host --restart unless-stopped \

--- a/scripts/start_sndr_daemon.sh
+++ b/scripts/start_sndr_daemon.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Canonical standalone sndr GUI daemon launcher (single-host / rig).
+# Fixes two classes of "GUI can't find engine" + "memory Error: Not Found"
+# that bite when the daemon is (re)created without the right env:
+#   - engine detection: the vLLM engine on :8102 needs its API key, else the
+#     probe gets 401 and falls back to an empty :8000.
+#   - persistent memory: GENESIS_MEMORY_DSN -> pgvector, and psycopg (NOT in the
+#     vLLM base image) must be pip-installed at boot, else it silently falls
+#     back to the ephemeral in-memory store (empties on every restart).
+# Override the engine/key/DSN via env before running. PROD engine is untouched.
+set -euo pipefail
+ENGINE_URL="${SNDR_OPENAI_BASE_URL:-http://127.0.0.1:8102/v1}"
+ENGINE_KEY="${SNDR_ENGINE_API_KEY:-genesis-local}"
+MEM_DSN="${GENESIS_MEMORY_DSN:-postgresql://genesis:genesis_mem_dev@127.0.0.1:55432/genesis_memory}"
+SNDR_SRC="${SNDR_SRC_DIR:-/home/sander/gvp-mainsync/sndr}"
+IMAGE="${SNDR_DAEMON_IMAGE:-vllm/vllm-openai:nightly}"
+docker rm -f sndr-daemon >/dev/null 2>&1 || true
+docker run -d --name sndr-daemon --network host --restart unless-stopped \
+  -e SNDR_OPENAI_BASE_URL="$ENGINE_URL" \
+  -e SNDR_ENGINE_API_KEY="$ENGINE_KEY" \
+  -e SNDR_METRICS_URL="${SNDR_METRICS_URL:-http://127.0.0.1:8102/metrics}" \
+  -e GENESIS_MEMORY_DSN="$MEM_DSN" \
+  -e GENESIS_MEMORY_EMBEDDER="${GENESIS_MEMORY_EMBEDDER:-hash}" \
+  -e GENESIS_MEMORY_DIM="${GENESIS_MEMORY_DIM:-256}" \
+  -e SNDR_ALLOW_ALL_ORIGINS=1 -e SNDR_RUNTIME_HOST=127.0.0.1 -e SNDR_GUI_PORT=8765 \
+  -e SNDR_ADMIN_PASSWORD="${SNDR_ADMIN_PASSWORD:-123456}" -e PYTHONDONTWRITEBYTECODE=1 \
+  -v "$SNDR_SRC":/usr/local/lib/python3.12/dist-packages/sndr:ro \
+  -v /nfs/genesis/models:/models:ro \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  --entrypoint sh "$IMAGE" \
+  -c 'pip install --quiet "psycopg[binary]>=3.1" 2>&1 | tail -1; exec python3 -c "from sndr.product_api.legacy.http_app import run_server; run_server(host=\"0.0.0.0\", port=8765, enable_apply=False)"'
+echo "sndr-daemon (re)created — engine=$ENGINE_URL, memory=pgvector"

--- a/tests/unit/compose/test_daemon_engine_memory_wiring.py
+++ b/tests/unit/compose/test_daemon_engine_memory_wiring.py
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Recurrence gate for the 2026-07-06 daemon-wiring incident.
+
+The full-product compose's sndr-daemon must ship the config that makes the
+GUI actually find the engine and persist memory. Both silently degrade if
+dropped:
+  - SNDR_ENGINE_API_KEY: without it the :8102 probe gets 401 -> "no engine".
+  - GENESIS_MEMORY_DSN + a pgvector service + psycopg install: without any of
+    them memory falls back to the ephemeral in-memory store -> GUI "Memory:
+    Error Not Found" and data lost on every restart.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+_COMPOSE = (
+    Path(__file__).resolve().parents[3] / "compose" / "docker-compose.full.yml"
+)
+
+
+def _compose() -> dict:
+    return yaml.safe_load(_COMPOSE.read_text(encoding="utf-8"))
+
+
+def test_daemon_carries_engine_key_and_url():
+    env = _compose()["services"]["sndr-daemon"]["environment"]
+    assert "SNDR_ENGINE_API_KEY" in env, "daemon must pass the engine API key"
+    assert "SNDR_OPENAI_BASE_URL" in env, "daemon must point at the engine URL"
+
+
+def test_daemon_wires_persistent_memory():
+    d = _compose()
+    env = d["services"]["sndr-daemon"]["environment"]
+    assert "GENESIS_MEMORY_DSN" in env, "daemon must set the pgvector DSN"
+    assert "memory-db" in d["services"], "a pgvector memory-db service must exist"
+    assert "psycopg" in str(d["services"]["sndr-daemon"]["entrypoint"]), (
+        "daemon entrypoint must pip-install psycopg (absent from the vLLM image)"
+    )
+
+
+def test_memory_db_is_pgvector_with_persistent_volume():
+    d = _compose()
+    mdb = d["services"]["memory-db"]
+    assert "pgvector" in mdb["image"]
+    assert d.get("volumes"), "memory-db needs a named volume for persistence"


### PR DESCRIPTION
Durable repo fix for the live 2026-07-06 daemon incident: the GUI couldn't find the engine (missing API key -> 401 -> fallback :8000) and memory showed 'Error: Not Found' / reset on restart (no GENESIS_MEMORY_DSN + psycopg absent from the vLLM image -> ephemeral in-memory fallback). compose gains a pgvector memory-db + daemon wiring + psycopg install; scripts/start_sndr_daemon.sh is the canonical single-host launcher; docs/GUI.md documents it; guard test prevents regression. Verified live: memory persists across daemon restart.