### PR TITLE
UX: wizard-first launch + cross-platform docs + zero-config (adapted from club-3090)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,74 @@
+# ══════════════════════════════════════════════════════════════════════
+#  Genesis / sndr — environment scaffold  (copy to `.env`, edit nothing to
+#  start; uncomment only what you want to override)
+# ══════════════════════════════════════════════════════════════════════
+#
+#  Quick start:
+#      cp .env.example .env
+#  On Linux + CUDA that is enough — every value below is AUTO-DEFAULTED by
+#  the code, so a `.env` with zero uncommented lines still boots a working
+#  stack (`sndr up` / install.sh). Uncomment a line only to override.
+#
+#  ── PRECEDENCE / CASE WARNINGS (read once) ──────────────────────────────
+#  • SHELL ENV WINS: a variable already exported in your shell overrides the
+#    value here (docker-compose semantics). `unset FOO` in your shell to let
+#    this file's value take effect.
+#  • This file is read LITERALLY as KEY=VALUE lines — it is NOT `source`d, so
+#    there is no shell expansion, no `$(...)`, no `${OTHER}` interpolation.
+#  • Keys are case-SENSITIVE and must be UPPER_SNAKE_CASE (SNDR_GUI_PORT, not
+#    sndr_gui_port). Unknown-case keys are silently ignored.
+#  • CRLF line endings and surrounding "quotes" are tolerated and stripped.
+#  • Blank values mean "unset / use the built-in default", not "empty string".
+#
+# ────────────────────────────────────────────────────────────────────────
+#  SECTION A — LOCAL FULL STACK  (Linux + CUDA; the engine runs here)
+#  Everything here is AUTO-DEFAULTED. Uncomment ONLY to override.
+# ────────────────────────────────────────────────────────────────────────
+#
+#   Engine selection (default: vllm — the only supported engine overlay).
+# SNDR_ENGINE=vllm
+#
+#   Engine OpenAI-compatible endpoint. Self-launch default is port 8000;
+#   the PROD rig serves on 8102. Leave unset on a self-launched local stack.
+# SNDR_OPENAI_BASE_URL=http://127.0.0.1:8000/v1
+#
+#   Bearer token your `curl` sends (Authorization: Bearer <key>). Blank = no
+#   key required. On Linux the daemon can also AUTO-DISCOVER the running
+#   container's key via the mounted docker socket, so you rarely set this.
+# SNDR_ENGINE_API_KEY=genesis-local
+# SNDR_ENGINE_KEY_AUTODISCOVER=1
+#
+#   Control Center GUI daemon port.
+# SNDR_GUI_PORT=8765
+#
+#   Persistent neural-graph memory. BLANK = ephemeral in-memory store (wiped
+#   on every restart — a transparent note is printed, not a silent fallback).
+#   Set it to the pgvector service for durable memory across restarts.
+# GENESIS_MEMORY_DSN=postgresql://genesis:genesis_mem_dev@127.0.0.1:55432/genesis_memory
+# GENESIS_MEMORY_EMBEDDER=hash
+# GENESIS_MEMORY_DIM=256
+#
+#   Model weights + host.yaml paths. AUTO-DETECTED at first run (host.yaml is
+#   written for you by the first-run auto-init). Override ONLY for a
+#   non-conventional layout; otherwise leave these commented.
+# SNDR_MODELS_DIR=/srv/models
+# SNDR_HOME=~/.sndr
+#
+# ────────────────────────────────────────────────────────────────────────
+#  SECTION B — REMOTE CLIENT  (Mac / Windows driving a remote rig)
+#  The engine cannot run here (needs Linux + CUDA). This triplet is the ONLY
+#  genuinely manual surface: point the CLI + GUI at your rig, then `sndr up
+#  --no-engine`. Uncomment and edit all three.
+# ────────────────────────────────────────────────────────────────────────
+#
+#   1) Rig engine endpoint (replace YOUR_RIG_HOST with your rig's host:port).
+# SNDR_OPENAI_BASE_URL=http://YOUR_RIG_HOST:8102/v1
+#
+#   2) Engine API key the rig expects (compose default is genesis-local).
+# SNDR_ENGINE_API_KEY=genesis-local
+#
+#   3) Remote pgvector memory DSN (replace YOUR_RIG_HOST + password).
+# GENESIS_MEMORY_DSN=postgresql://genesis:genesis_mem_dev@YOUR_RIG_HOST:55432/genesis_memory
+#
+#   Optional: metrics endpoint on the rig (GUI charts).
+# SNDR_METRICS_URL=http://YOUR_RIG_HOST:8102/metrics

--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,8 @@ CLAUDE.md
 # Environment/secrets
 .env
 .env.*
+# ...but the committed, secret-free scaffold IS tracked (copy it to .env).
+!.env.example
 *.key
 *.pem
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,13 @@ at the Control Center (`http://127.0.0.1:8765`). Prefer the terminal?
 `sndr run` does the same and drops you straight into a chat prompt. New here?
 Start with [`docs/GETTING_STARTED.md`](docs/GETTING_STARTED.md).
 
+> **The engine needs Linux + CUDA + Docker.** On a Mac or Windows laptop you
+> can't run the engine locally — but you *can* drive a Linux rig remotely with
+> the same `sndr` CLI and GUI. See [`docs/RUN_ON_MAC.md`](docs/RUN_ON_MAC.md)
+> (Mac), [`docs/RUN_ON_WINDOWS_WSL.md`](docs/RUN_ON_WINDOWS_WSL.md) (Windows),
+> [`docs/RUN_ON_LINUX.md`](docs/RUN_ON_LINUX.md) (full local stack), and
+> [`docs/REMOTE_ENGINE.md`](docs/REMOTE_ENGINE.md) (client-mode reference).
+
 ![SNDR Control Center — system map with 329-patch registry, 15 presets, 12 models and live launch-readiness gates](docs/assets/screenshots/control-center.png)
 
 ## Who is this for
@@ -203,10 +210,15 @@ sndr launch prod-qwen3.6-35b-balanced            # boot a preset
 sndr launch prod-qwen3.6-35b-balanced --dry-run  # inspect the rendered command, no boot
 ```
 
-> Note: `prod-qwen3.6-35b-balanced` is the shipped **K=3** balanced default.
-> The headline numbers below come from the live PROD stack at **MTP K=5**
-> (re-tuned 2026-06-19, +15.8 % single-stream vs K=3) — expect the K=3 preset
-> to land correspondingly below the K=5 figures.
+> Note: `prod-qwen3.6-35b-balanced` is the shipped **K=3** balanced default —
+> and the right pick for a **single user** at a keyboard (latency-tuned,
+> `max_num_seqs=2`). It is what the zero-decision `sndr up` / `sndr quickstart`
+> auto-picks for a lone-user rig. Reach for `prod-qwen3.6-35b-multiconc` **only**
+> when serving many concurrent requests — it is throughput-tuned
+> (`max_num_seqs=8`, ~672 t/s aggregate) and trades single-stream latency for
+> that aggregate. The headline numbers below come from the live PROD stack at
+> **MTP K=5** (re-tuned 2026-06-19, +15.8 % single-stream vs K=3) — expect the
+> K=3 preset to land correspondingly below the K=5 figures.
 
 Full operator manual: [`docs/USAGE.md`](docs/USAGE.md).
 
@@ -426,6 +438,15 @@ endpoint, config, security, and troubleshooting:
 | **2× cards** (TP=2 — the reference topology) | [`docs/HARDWARE.md`](docs/HARDWARE.md) + [`docs/MODELS.md`](docs/MODELS.md) |
 | **A model not in the catalog** | [`docs/MODELS.md`](docs/MODELS.md) (add-a-model + the V2 config system) |
 | **Brand-new / weighing self-host vs cloud** | [`docs/GETTING_STARTED.md`](docs/GETTING_STARTED.md) · [`docs/COMPARISONS.md`](docs/COMPARISONS.md) |
+
+**I want to… (by machine):**
+
+| I want to… | Read |
+| --- | --- |
+| Run the full stack locally on a **Linux + CUDA** box | [`docs/RUN_ON_LINUX.md`](docs/RUN_ON_LINUX.md) |
+| Drive a rig from a **Mac** (client mode) | [`docs/RUN_ON_MAC.md`](docs/RUN_ON_MAC.md) |
+| Run on **Windows / WSL2** (GPU passthrough or client) | [`docs/RUN_ON_WINDOWS_WSL.md`](docs/RUN_ON_WINDOWS_WSL.md) |
+| Point the GUI / CLI at a **remote engine** | [`docs/REMOTE_ENGINE.md`](docs/REMOTE_ENGINE.md) |
 
 ## Install & run
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -49,11 +49,41 @@ Then **three commands** take you from install to a chat prompt — they are laid
 out, with expected output, in [`QUICKSTART.md`](QUICKSTART.md). Prefer a manual
 clone instead of the installer? That path is in [`INSTALL.md`](INSTALL.md).
 
+**Zero-decision default:** on a Linux + CUDA box, one command does the whole
+arc — `sndr quickstart` auto-detects your GPU, fits a preset, downloads the
+weights, boots the engine, and opens the GUI. (`sndr up` does the same;
+`sndr run` ends at a terminal chat instead.) The full-stack front door with the
+workload → preset table is [`RUN_ON_LINUX.md`](RUN_ON_LINUX.md).
+
+## No Linux GPU? Drive a rig instead
+
+The engine needs **Linux + CUDA + Docker** — a Mac or a GPU-less Windows
+laptop can't run it locally. That is **not** a dead end: the same `sndr` CLI
+and GUI run in **client mode** and drive a Linux rig over the network. Three
+commands:
+
+```bash
+sndr remote setup http://<rig>:8102/v1   # point at the rig's engine (key: genesis-local)
+sndr up --no-engine                      # start the local GUI daemon, no local engine
+sndr chat                                # chat against the remote engine
+```
+
+`<rig>` is your rig's hostname or LAN IP; `:8102` is the PROD engine port; the
+engine is keyed (`genesis-local` by default). Per-OS walk-throughs:
+[`RUN_ON_MAC.md`](RUN_ON_MAC.md) · [`RUN_ON_WINDOWS_WSL.md`](RUN_ON_WINDOWS_WSL.md).
+The canonical client-mode reference (the env triplet, memory DSN, ports, the
+`401` cause) is [`REMOTE_ENGINE.md`](REMOTE_ENGINE.md). No rig yet? Stand one up
+with [`RUN_ON_LINUX.md`](RUN_ON_LINUX.md).
+
 ## Where to go next
 
 | If you want to... | Read |
 | --- | --- |
 | Clone → first token, with the actual commands | [`QUICKSTART.md`](QUICKSTART.md) |
+| Run the full stack locally on **Linux + CUDA** | [`RUN_ON_LINUX.md`](RUN_ON_LINUX.md) |
+| Drive a rig from a **Mac** | [`RUN_ON_MAC.md`](RUN_ON_MAC.md) |
+| Run on **Windows / WSL2** (GPU passthrough or client) | [`RUN_ON_WINDOWS_WSL.md`](RUN_ON_WINDOWS_WSL.md) |
+| Point the GUI / CLI at a **remote engine** | [`REMOTE_ENGINE.md`](REMOTE_ENGINE.md) |
 | Use the browser GUI (`sndr up` / `sndr open`, port 8765) | [`GUI.md`](GUI.md) |
 | Drive everything from one keyboard screen (no commands to memorise) | [`TUI.md`](TUI.md) |
 | Understand local AI from scratch (hardware / engines / quants) | [`LOCAL_AI_PRIMER.md`](LOCAL_AI_PRIMER.md) |

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -80,6 +80,24 @@ When you are done:
 sndr down      # stop the engine + GUI started by `sndr up`
 ```
 
+### No local GPU? Drive a rig instead
+
+The steps above assume a **Linux + CUDA + Docker** box — that is what runs the
+engine. On a Mac, or a GPU-less Windows laptop, you can't run the engine
+locally, but the same `sndr` CLI + GUI drive a Linux rig over the network.
+Three commands:
+
+```bash
+sndr remote setup http://<rig>:8102/v1   # point at the rig's engine (key: genesis-local)
+sndr up --no-engine                      # start the local GUI daemon, no local engine
+sndr chat                                # chat against the remote engine
+```
+
+`<rig>` is the rig's hostname or LAN IP; `:8102` is the PROD engine port; the
+engine is keyed (`genesis-local` by default). Full per-OS walk-throughs:
+[`RUN_ON_MAC.md`](RUN_ON_MAC.md) · [`RUN_ON_WINDOWS_WSL.md`](RUN_ON_WINDOWS_WSL.md);
+canonical client-mode reference: [`REMOTE_ENGINE.md`](REMOTE_ENGINE.md).
+
 ---
 
 ## More — when you outgrow the defaults
@@ -101,8 +119,8 @@ Pick by hardware shape:
 
 | Hardware | Preset | Notes |
 | --- | --- | --- |
-| 2× RTX A5000 24 GB | `prod-qwen3.6-35b-balanced` | Flagship — Qwen3.6-35B-A3B (MoE), ~242 TPS single-stream (MTP K=5; measured 2026-07-04 on pin `dev748`, AWQ checkpoint). |
-| 2× RTX A5000 multi-conc | `prod-qwen3.6-35b-multiconc` | `max_num_seqs=8`, aggregate ~672 TPS (K=3 multi-conc measurement, 2026-05-23 — see [`BENCHMARKS.md`](BENCHMARKS.md)). |
+| 2× RTX A5000 24 GB (**single user**) | `prod-qwen3.6-35b-balanced` | Flagship lone-user default — Qwen3.6-35B-A3B (MoE), latency-tuned (`max_num_seqs=2`), ~242 TPS single-stream (MTP K=5; measured 2026-07-04 on pin `dev748`, AWQ checkpoint). This is what `sndr up` / `sndr quickstart` auto-picks. |
+| 2× RTX A5000 (**many concurrent requests**) | `prod-qwen3.6-35b-multiconc` | Throughput-tuned `max_num_seqs=8`, aggregate ~672 TPS (K=3 multi-conc measurement, 2026-05-23 — see [`BENCHMARKS.md`](BENCHMARKS.md)). Picks up aggregate at the cost of single-stream latency — choose it only when you actually run concurrent load, not for solo chat. |
 | 2× 24 GB (3090 / 4090 / A5000) | `prod-qwen3.6-27b-tq-k8v4` | Lorbus 27B int4 + TurboQuant k8v4 (long context). |
 | 1× RTX A5000 / 3090 | `qa-qwen3.6-27b-tq-1x` | TP=1, 78K context. |
 
@@ -160,14 +178,28 @@ curl -s -X POST http://localhost:8000/v1/chat/completions \
     }'
 ```
 
+> **The engine is keyed.** That `Authorization: Bearer genesis-local` header is
+> **not** optional — `genesis-local` is the shipped default key. Omit it and
+> every request comes back `401 Unauthorized` (and the GUI reports "no
+> engine"). If the operator launched with a different `--api-key`, use that
+> string instead. This one missing header is the most common first-curl
+> stumble — see [`REMOTE_ENGINE.md`](REMOTE_ENGINE.md) and
+> [`TROUBLESHOOTING.md`](TROUBLESHOOTING.md).
+
 ### Stopping cleanly
 
-Use `sndr down` to stop the stack `sndr up` started. Avoid a plain
-`docker stop` + `docker start`: that recycles the same writable layer, and
-Genesis text-patches applied to that layer fail to re-apply on the next boot
-(anchors don't match). The recovery for a stuck container is a full
-`docker compose down` → `docker compose up -d`. The "R/W layer trap" and
-other cliffs are catalogued in [`TROUBLESHOOTING.md`](TROUBLESHOOTING.md).
+> **Safe stop = `sndr down`.** Do **not** stop the stack with a plain
+> `docker stop` + `docker start`. That recycles the same writable layer, and
+> the Genesis text-patches applied to that layer **fail to re-apply** on the
+> next boot (the anchors no longer match a patched file) — the container comes
+> back subtly broken. Always `sndr down`. The recovery for a container already
+> stuck this way is a full `docker compose down` → `docker compose up -d` (a
+> fresh layer). This "R/W layer trap" and the other named cliffs are
+> catalogued in [`TROUBLESHOOTING.md`](TROUBLESHOOTING.md).
+
+```bash
+sndr down      # stop the engine + GUI cleanly (re-applies patches correctly next boot)
+```
 
 ## What's next
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,10 @@ never ship publicly.
 | If you want to... | Read |
 | --- | --- |
 | **Brand-new** — orient, then clone to first token | [`GETTING_STARTED.md`](GETTING_STARTED.md) |
+| Run the full stack locally on **Linux + CUDA** | [`RUN_ON_LINUX.md`](RUN_ON_LINUX.md) |
+| Drive a rig from a **Mac** (client mode) | [`RUN_ON_MAC.md`](RUN_ON_MAC.md) |
+| Run on **Windows / WSL2** (GPU passthrough or client) | [`RUN_ON_WINDOWS_WSL.md`](RUN_ON_WINDOWS_WSL.md) |
+| Point the GUI / CLI at a **remote engine** | [`REMOTE_ENGINE.md`](REMOTE_ENGINE.md) |
 | Understand how the whole platform is put together (structure + data flows) | [`ARCHITECTURE.md`](ARCHITECTURE.md) |
 | New to local AI itself (hardware / engines / quants, plain English) | [`LOCAL_AI_PRIMER.md`](LOCAL_AI_PRIMER.md) |
 | Weigh self-host vs a cloud API, or vs other local engines | [`COMPARISONS.md`](COMPARISONS.md) |
@@ -35,7 +39,7 @@ never ship publicly.
 | Browse the patch catalogue + compatibility matrix | [`PATCHES.md`](PATCHES.md) |
 | Read the technical design appendices (PN95, GDN, ...) | [`PATCH_DESIGNS.md`](PATCH_DESIGNS.md) |
 
-## File catalogue (45 markdown files)
+## File catalogue (49 markdown files)
 
 ### Onboarding & concepts
 
@@ -56,6 +60,15 @@ never ship publicly.
 | [`TUI.md`](TUI.md) | The terminal cockpit (`sndr tui`) — panes, keys, beginner mode, offline rig planning. |
 | [`PRODUCT_API.md`](PRODUCT_API.md) | The typed read-only Product API behind CLI/GUI/SDK + the `:8765` HTTP daemon route map. |
 | [`MCP.md`](MCP.md) | The MCP server (stdio JSON-RPC) exposing the Ops Copilot tool catalog to Claude Desktop / Cursor / IDE agents. |
+
+### Run it — per machine (situation docs)
+
+| Doc | Purpose |
+| --- | --- |
+| [`RUN_ON_LINUX.md`](RUN_ON_LINUX.md) | Full-stack front door for the Linux + CUDA + Docker box that runs the engine — warning-first, workload → preset → ctx → TPS → VRAM table, zero-decision `sndr quickstart`, expert paths preserved. |
+| [`RUN_ON_MAC.md`](RUN_ON_MAC.md) | Honest Mac page — the engine can't run on a Mac; drive a Linux rig in client mode (CLI + GUI + memory) with the three-command remote path. |
+| [`RUN_ON_WINDOWS_WSL.md`](RUN_ON_WINDOWS_WSL.md) | Windows, two honest lanes — WSL2 + NVIDIA passthrough (follow RUN_ON_LINUX) or client mode (no GPU); never a native-Windows engine. |
+| [`REMOTE_ENGINE.md`](REMOTE_ENGINE.md) | Canonical client-mode reference — the `SNDR_OPENAI_BASE_URL` triplet, where each value comes from, CLI/GUI consumption, memory-DSN persistence, the `:8000` vs `:8102` port story, the `401` cause. |
 
 ### Installation & quickstart
 

--- a/docs/REMOTE_ENGINE.md
+++ b/docs/REMOTE_ENGINE.md
@@ -1,0 +1,156 @@
+# Remote engine — drive a rig from anywhere (client mode)
+
+This is the canonical reference for **client mode**: running the `sndr` CLI,
+the GUI Control Center, and the persistent memory *against an engine that
+lives on another machine*. If your laptop can't run the engine (Mac, or
+Windows without a GPU), or you simply keep the GPU box in a closet, this is
+how you point everything at it.
+
+> **The honest hardware truth.** The SNDR Core engine runs on **Linux +
+> CUDA + Docker** only — the reference rig is 2× RTX A5000 / 3090 (Ampere
+> `sm_86`), one heavy model at a time. macOS and Windows **cannot** run the
+> engine. What they *can* do — fully — is run the `sndr` CLI, the GUI daemon
+> (`:8765`), and the memory client as a **remote control** for a Linux rig.
+> Per-OS front doors: [`RUN_ON_MAC.md`](RUN_ON_MAC.md) ·
+> [`RUN_ON_WINDOWS_WSL.md`](RUN_ON_WINDOWS_WSL.md) ·
+> [`RUN_ON_LINUX.md`](RUN_ON_LINUX.md) (full local stack).
+
+## The triplet
+
+Everything client-mode needs collapses to three environment variables:
+
+| Variable | Example | What it points at |
+| --- | --- | --- |
+| `SNDR_OPENAI_BASE_URL` | `http://<rig>:8102/v1` | The engine's OpenAI-compatible API on the rig. `<rig>` is the rig's hostname or LAN IP; `8102` is the PROD serving port. |
+| `SNDR_ENGINE_API_KEY` | `genesis-local` | The engine's API key. `genesis-local` is the shipped default; whatever the rig launched with (`--api-key`) is what you paste here. |
+| `GENESIS_MEMORY_DSN` | `postgresql://genesis:<pw>@<rig>:55432/genesis_memory` | The rig's pgvector Postgres for persistent neural-graph memory. Optional — see [Memory DSN behavior](#memory-dsn-behavior) below. |
+
+Set them once (a `.env` next to your clone, or exported in your shell) and the
+CLI, the GUI, and `sndr mem` all read the same three values.
+
+### Where each value comes from
+
+- **`SNDR_OPENAI_BASE_URL`** — the rig's address plus the engine port. The
+  PROD 35B lane serves on **`:8102`** (see the [port story](#the-8000-vs-8102-port-story)
+  below for why it is not `:8000`). Always end the URL in `/v1`.
+- **`SNDR_ENGINE_API_KEY`** — the key the engine was booted with. Genesis
+  ships **`genesis-local`** as the default; if the operator overrode
+  `--api-key` on the launch, use that string. This is the single most common
+  cause of a "can't find engine" symptom — see [401](#the-401-story-missing-bearer)
+  below.
+- **`GENESIS_MEMORY_DSN`** — the connection string for the rig's
+  `genesis-memory-db` pgvector container (default dim 256 = the built-in hash
+  embedder; schema tables `mem_node` / `mem_edge`). Deployment recipe for that
+  container: [`memory/MANUAL.md`](memory/MANUAL.md).
+
+> **Shell env wins.** If a variable is exported in your shell, it overrides
+> the value in a `.env` file and the value `sndr remote setup` wrote. This is
+> deliberate — a one-off `SNDR_OPENAI_BASE_URL=… sndr chat` beats your saved
+> default — but it also means a stale export in your `~/.zshrc` silently wins
+> over the `.env` you just edited. When a value "won't take", check
+> `env | grep -E 'SNDR_|GENESIS_MEMORY'` first.
+
+## How the CLI consumes it
+
+```bash
+# 1. one-shot setup — writes the base URL (and prompts for the key) into your
+#    client profile so you don't re-type it
+sndr remote setup http://<rig>:8102/v1
+
+# 2. start ONLY the GUI daemon locally; do NOT try to launch an engine
+sndr up --no-engine
+
+# 3. chat straight against the remote engine
+sndr chat
+```
+
+- **`sndr remote setup <base-url>`** records the remote engine as your default
+  target (base URL + key) so subsequent commands need no flags.
+- **`sndr up --no-engine`** starts the local GUI daemon **without** attempting
+  to boot an engine — because the engine already runs on the rig. The daemon
+  then talks to `SNDR_OPENAI_BASE_URL`. (On a Mac/Windows client you always
+  want `--no-engine`; there is no local engine to start.)
+- **`sndr chat`** opens a terminal chat against whatever
+  `SNDR_OPENAI_BASE_URL` + `SNDR_ENGINE_API_KEY` resolve to — remote or local,
+  it is the same command.
+
+A raw `curl` works too, and shows exactly what the CLI sends under the hood —
+note the **`Authorization: Bearer genesis-local`** header, which is not
+optional:
+
+```bash
+curl -s -X POST http://<rig>:8102/v1/chat/completions \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer genesis-local" \
+    -d '{"model":"qwen3.6-35b-a3b",
+         "messages":[{"role":"user","content":"Say hello in one word."}],
+         "max_tokens":16,"temperature":0}'
+```
+
+## How the GUI consumes it
+
+The GUI daemon (`sndr-daemon`, port **`:8765`**) reads the same triplet from
+its environment:
+
+- It probes the engine's `/v1/models` at `SNDR_OPENAI_BASE_URL` using
+  `SNDR_ENGINE_API_KEY`. A keyless probe against a keyed engine returns
+  `401`, which the daemon reads as **"no engine"** and then falls back to an
+  empty `:8000` — the classic "GUI says no engine" trap. Passing the key fixes
+  it.
+- Its Memory panel uses `GENESIS_MEMORY_DSN` to reach pgvector; unset means an
+  ephemeral in-memory store (below).
+
+The full daemon config, security model, and screenshots are in
+[`GUI.md`](GUI.md); the typed daemon route map is in
+[`PRODUCT_API.md`](PRODUCT_API.md).
+
+## Memory DSN behavior
+
+The memory backend is chosen **entirely** by whether `GENESIS_MEMORY_DSN` is
+set:
+
+| `GENESIS_MEMORY_DSN` | Backend | Persistence |
+| --- | --- | --- |
+| **set** (points at pgvector) | Postgres + pgvector (`PostgresStore`) | **Persistent** — nodes/edges survive restarts; this is what you want for a real memory. |
+| **unset** | `InMemoryStore` (RAM) | **Ephemeral** — every daemon restart starts empty. Fine for a quick try, useless as a long-term brain. |
+
+Two gotchas the rig launcher already handles, worth knowing when you self-host
+the memory container: the DSN must point at the `genesis-memory-db` pgvector
+instance (dim 256, tables `mem_node` / `mem_edge`), and `psycopg` is **not** in
+the vLLM base image — the daemon `pip install psycopg[binary]>=3.1` at boot,
+otherwise `PostgresStore` import fails and it *silently* falls back to
+in-memory. Full deployment: [`memory/MANUAL.md`](memory/MANUAL.md).
+
+## The `:8000` vs `:8102` port story
+
+You will see both ports in the wild:
+
+- **`:8000`** is vLLM's stock default and what a bare `vllm serve` binds. Some
+  older GUI engine-detect paths still probe `:8000` first.
+- **`:8102`** is where the Genesis **PROD 35B lane actually serves** on the
+  reference rig. When you drive a remote rig, `SNDR_OPENAI_BASE_URL` must name
+  the port the engine really listens on — **`:8102`** for the canonical PROD
+  stack. If you launched a bring-up engine on the vanilla `:8000`, point the
+  URL there instead. The launcher varies the port, so always confirm with the
+  rig operator or `docker ps` on the rig rather than assuming.
+
+## The 401 story (missing Bearer)
+
+By far the most common client-mode failure: the engine is up and healthy, but
+every request comes back `401 Unauthorized` — and the GUI reports **"no
+engine"**. The engine is **keyed**. The fix is to send the key:
+
+- CLI / curl: `Authorization: Bearer genesis-local` (or your override).
+- GUI daemon: set `SNDR_ENGINE_API_KEY=genesis-local`.
+- Env: make sure `SNDR_ENGINE_API_KEY` is actually exported / in `.env` and
+  not shadowed by an empty shell export (see *shell env wins* above).
+
+`genesis-local` is the shipped default key. More failure modes and their cures
+are in [`TROUBLESHOOTING.md`](TROUBLESHOOTING.md).
+
+## See also
+
+- [`RUN_ON_MAC.md`](RUN_ON_MAC.md) — the Mac client front door (uses this triplet).
+- [`RUN_ON_WINDOWS_WSL.md`](RUN_ON_WINDOWS_WSL.md) — Windows: GPU passthrough or client mode.
+- [`RUN_ON_LINUX.md`](RUN_ON_LINUX.md) — run the **full** stack locally on a Linux + CUDA box.
+- [`GUI.md`](GUI.md) · [`PRODUCT_API.md`](PRODUCT_API.md) · [`memory/MANUAL.md`](memory/MANUAL.md).

--- a/docs/RUN_ON_LINUX.md
+++ b/docs/RUN_ON_LINUX.md
@@ -1,0 +1,140 @@
+# Run on Linux — the full stack, locally
+
+This is the front door for the machine that actually runs the engine: a
+**Linux box with an NVIDIA CUDA GPU and Docker**. On this hardware you get the
+whole platform — the patched vLLM engine, the GUI Control Center, and the
+persistent memory — running locally. Mac and Windows users drive a box like
+this remotely; see [`RUN_ON_MAC.md`](RUN_ON_MAC.md) /
+[`RUN_ON_WINDOWS_WSL.md`](RUN_ON_WINDOWS_WSL.md).
+
+> **What "the engine" needs.** The engine is **Linux + CUDA + Docker** only.
+> The reference rig is **2× RTX A5000 / 3090, 24 GB each, Ampere `sm_86`**,
+> TP=2 for the big models. A single 24 GB card runs the 27B lane; the 35B MoE
+> wants two. Current pin **`dev748`** (`0.23.1rc1.dev748+g2dfaae752`), 329
+> patches auto-applied at boot.
+
+## Read this first (the one warning that matters)
+
+**One heavy model at a time.** Both GPUs are occupied by a big model at TP=2;
+you cannot run two 24 GB-class models concurrently on a 2-card rig. Boot one,
+stop it with `sndr down`, then boot the next.
+
+**Never interrupt a production engine.** If a rig is already serving (the
+reference PROD lane is `:8102`), do **not** `docker stop` it or launch a second
+heavy model on the same cards — you will evict the running model. Check
+`docker ps` before you launch.
+
+**Stop with `sndr down`, not `docker stop`.** A plain `docker stop` +
+`docker start` recycles the same writable layer, and the Genesis text-patches
+applied to that layer fail to re-apply on the next boot (anchors no longer
+match). Always use `sndr down`. Recovery for a stuck container is a full
+`docker compose down` → `docker compose up -d`. Details:
+[`TROUBLESHOOTING.md`](TROUBLESHOOTING.md).
+
+## The zero-decision path
+
+If you don't want to think about presets at all:
+
+```bash
+# 1. install — detects OS / Python / GPU / vLLM, installs the plugin + `sndr`
+curl -sSL https://raw.githubusercontent.com/Sandermage/sndr_core_engine/main/install.sh | bash
+
+# 2. one command: auto-detect the GPU → fit a preset → download weights → boot → open the GUI
+sndr quickstart          # equivalently: `sndr up` (auto-picks a preset for your rig)
+```
+
+`sndr quickstart` auto-detects your card, picks a fitting preset, pulls the
+weights (skipped if present), launches the engine **and** the Control Center,
+and opens your browser at `http://127.0.0.1:8765`. Prefer a terminal chat
+instead of the GUI? `sndr run` does the same and drops you at a prompt. That is
+the whole zero-decision arc — no config files.
+
+Want to lock in a specific model as your default so `sndr up` always boots it?
+After the first boot the CLI offers to pin your choice; you can also always be
+explicit with `sndr up <preset>` (expert path, below).
+
+## Pick a workload
+
+Every preset below runs through the launcher — `sndr up <preset>` boots it,
+`sndr launch <preset> --dry-run` shows the rendered `docker run` without
+booting. Numbers are single-stream decode on the reference **2× A5000** rig,
+labeled with (pin, date); full methodology and per-rig reproduction in
+[`BENCHMARKS.md`](BENCHMARKS.md).
+
+| Workload | Preset | Max ctx | Single-stream TPS | Topology |
+| --- | --- | ---: | ---: | --- |
+| **IDE agents / low-latency chat** | `prod-qwen3.6-35b-balanced` | 280K | ~223.9 t/s (dev748, 2026-07-04; AWQ PROD lane 242.5) | 2× A5000 TP=2 |
+| **High-concurrency serving** | `prod-qwen3.6-35b-multiconc` | 280K | ~672 t/s aggregate @ conc=8 (K=3, 2026-05-23) | 2× A5000 TP=2 |
+| **RAG / long-context (27B)** | `prod-qwen3.6-27b-tq-k8v4` | 262K | ~130 t/s (2026-07-04 sweep) | 2× A5000 TP=2 |
+| **Single-card 27B** | `qa-qwen3.6-27b-tq-1x` | 78K | ~108–125 t/s | 1× A5000 / 3090 TP=1 |
+| **Multimodal / structured (Gemma 4)** | `prod-gemma4-26b-default` | 262K | ~141 t/s (dev748, 2026-07-04) | 2× A5000 TP=2 |
+| **Block-diffusion text (experimental)** | `prod-diffusiongemma-tp2` | 128K | n/a (diffusion; AR TPS not applicable) | 2× A5000 TP=2 |
+
+### Workload: IDE agents / low-latency chat
+
+The flagship for a **single user**. Boot the balanced 35B:
+
+```bash
+sndr up prod-qwen3.6-35b-balanced
+```
+
+`prod-qwen3.6-35b-balanced` is the right default for one person at a keyboard —
+it is latency-tuned (`max_num_seqs=2`), serves the full 280K context, and keeps
+tool-calling clean (7/7 on the dev748 promotion gate). Use
+`prod-qwen3.6-35b-multiconc` **only** when you are serving many concurrent
+requests: it is throughput-tuned (`max_num_seqs=8`, ~672 t/s aggregate) and
+trades single-stream latency for that aggregate. For one user, balanced wins.
+
+### Workload: RAG / long-context
+
+Big-document retrieval and long chats on the 27B INT4 lane at 262K context:
+
+```bash
+sndr up prod-qwen3.6-27b-tq-k8v4
+```
+
+TurboQuant `k8v4` KV-cache quant is what makes the long context fit. On a
+single 24 GB card use `qa-qwen3.6-27b-tq-1x` (78K context, TP=1) — see
+[`SINGLE_CARD.md`](SINGLE_CARD.md) for the single-card cliff story and escape
+hatches. (The 27B model loops in thinking mode — a known model trait; chat with
+`enable_thinking:false`.)
+
+### Workload: multimodal / structured (Gemma 4)
+
+```bash
+sndr up prod-gemma4-26b-default
+```
+
+Gemma 4 26B-A4B for structured / multimodal-adjacent work at 262K context. The
+31B variant (`prod-gemma4-31b-kvauto-chat`) also boots and serves chat +
+tool-calls on this rig.
+
+## Expert path (kept, always works)
+
+The zero-decision surface is additive — none of the explicit controls went
+away:
+
+```bash
+sndr preset list                                   # browse presets for your rig
+sndr launch prod-qwen3.6-35b-balanced --dry-run    # render the docker command + patch plan, boot nothing
+sndr up prod-qwen3.6-35b-balanced                  # boot an explicit preset
+sndr config diff prod-qwen3.6-35b-balanced prod-qwen3.6-27b-tq-k8v4
+sndr down                                          # safe stop
+```
+
+Full operator manual: [`USAGE.md`](USAGE.md). Every `sndr` command:
+[`CLI_REFERENCE.md`](CLI_REFERENCE.md). Env-flag tuning:
+[`CONFIGURATION.md`](CONFIGURATION.md).
+
+## Where to go next
+
+| If you want to… | Read |
+| --- | --- |
+| The 5-minute clone-to-chat path | [`QUICKSTART.md`](QUICKSTART.md) |
+| Full installer flag matrix | [`INSTALL.md`](INSTALL.md) |
+| Set up `~/.sndr/host.yaml` (weights paths + mounts) | [`HOST_SETUP.md`](HOST_SETUP.md) |
+| Single 3090 / 4090 / A5000 | [`SINGLE_CARD.md`](SINGLE_CARD.md) |
+| Pick a model + hardware combo | [`MODELS.md`](MODELS.md) + [`HARDWARE.md`](HARDWARE.md) |
+| Day-2 operations (swaps, rollbacks, hygiene) | [`OPERATIONS.md`](OPERATIONS.md) |
+| Drive this rig from a Mac / Windows laptop | [`RUN_ON_MAC.md`](RUN_ON_MAC.md) · [`REMOTE_ENGINE.md`](REMOTE_ENGINE.md) |
+| Diagnose an OOM, cliff, or boot failure | [`TROUBLESHOOTING.md`](TROUBLESHOOTING.md) |

--- a/docs/RUN_ON_MAC.md
+++ b/docs/RUN_ON_MAC.md
@@ -1,0 +1,88 @@
+# Run on a Mac — drive a rig from your laptop
+
+**Your Mac cannot run the engine.** The SNDR Core engine needs **Linux +
+CUDA + Docker** and an NVIDIA GPU — Apple Silicon and Intel Macs have none of
+that, and there is no native-Mac engine (and won't be one). That is the honest
+situation, stated up front so you don't spend an afternoon fighting it.
+
+**What your Mac *can* do — fully:** run the `sndr` CLI, the GUI Control Center
+(`:8765`), and the memory client as a **remote control** for a Linux rig. You
+chat, launch presets, watch the patch summary, and browse the memory graph from
+macOS; the tokens are generated on the rig. If you have a Linux + CUDA box on
+your LAN (or a cloud GPU host), this is a first-class way to use it.
+
+> No rig yet? You need a Linux machine with an NVIDIA GPU to be the engine —
+> set that up with [`RUN_ON_LINUX.md`](RUN_ON_LINUX.md), then come back here to
+> point your Mac at it.
+
+## The client path (three commands)
+
+```bash
+# 1. install the CLI + GUI in client profile (no engine, no CUDA needed)
+curl -sSL https://raw.githubusercontent.com/Sandermage/sndr_core_engine/main/install.sh | bash -s -- --client
+
+# 2. point it at your rig's engine (writes the base URL + prompts for the key)
+sndr remote setup http://<rig>:8102/v1
+
+# 3. start the local GUI daemon WITHOUT an engine, then chat
+sndr up --no-engine
+sndr chat
+```
+
+`<rig>` is your rig's hostname or LAN IP; `:8102` is the PROD engine port. The
+engine is keyed — the default key is **`genesis-local`** (paste whatever the
+rig launched with). `sndr up --no-engine` is the key flag on a client: it
+starts only the GUI daemon and never tries to boot a local engine.
+
+## The `.env` alternative
+
+Prefer a file over `sndr remote setup`? Copy the example and fill in the three
+values (the **remote-client triplet**):
+
+```bash
+cp .env.example .env      # then edit .env
+```
+
+```bash
+# .env — the three values that define client mode
+SNDR_OPENAI_BASE_URL=http://<rig>:8102/v1
+SNDR_ENGINE_API_KEY=genesis-local
+GENESIS_MEMORY_DSN=postgresql://genesis:<pw>@<rig>:55432/genesis_memory   # optional
+```
+
+- **`SNDR_OPENAI_BASE_URL`** — the rig's engine, ending in `/v1`.
+- **`SNDR_ENGINE_API_KEY`** — the engine key (`genesis-local` by default). Skip
+  it and every request is `401` and the GUI reports "no engine".
+- **`GENESIS_MEMORY_DSN`** — optional; set it to the rig's pgvector for
+  persistent memory, leave it unset for an ephemeral in-memory store that
+  empties on restart.
+
+> **Shell env wins.** A variable exported in your shell (e.g. in `~/.zshrc`)
+> overrides both `.env` and what `sndr remote setup` saved. If a value "won't
+> take", run `env | grep -E 'SNDR_|GENESIS_MEMORY'` and clear the stale export.
+
+## What you get on the Mac
+
+- `sndr chat` — terminal chat against the remote engine.
+- `sndr up --no-engine` → `http://127.0.0.1:8765` — the full GUI Control Center
+  in your browser, driving the remote engine (launch presets, live patch
+  summary, benches, the 🧠 memory graph).
+- `sndr mem …` — remember / recall / search against the rig's memory.
+
+The one thing you cannot do is `sndr up` *with* a local engine — there is no
+CUDA on the Mac to run it. Always pass `--no-engine`.
+
+## The deep reference
+
+Everything about client mode — where each of the three values comes from, how
+the CLI and GUI consume them, the memory-DSN persistence table, the `:8000` vs
+`:8102` port story, and why a missing `Bearer genesis-local` causes a `401` —
+lives in **[`REMOTE_ENGINE.md`](REMOTE_ENGINE.md)**.
+
+## See also
+
+- [`REMOTE_ENGINE.md`](REMOTE_ENGINE.md) — the canonical client-mode reference.
+- [`RUN_ON_LINUX.md`](RUN_ON_LINUX.md) — stand up the rig that will be your engine.
+- [`RUN_ON_WINDOWS_WSL.md`](RUN_ON_WINDOWS_WSL.md) — the Windows equivalent of this page.
+- [`GUI.md`](GUI.md) — the Control Center in depth.
+- [`TROUBLESHOOTING.md`](TROUBLESHOOTING.md) — `401`, "no engine", memory-empty.

--- a/docs/RUN_ON_WINDOWS_WSL.md
+++ b/docs/RUN_ON_WINDOWS_WSL.md
@@ -1,0 +1,91 @@
+# Run on Windows — WSL2 with a GPU, or client mode
+
+There is **no native-Windows engine**, and there won't be one — the SNDR Core
+engine needs **Linux + CUDA + Docker**. On Windows you have two honest lanes,
+depending on whether the machine has an NVIDIA GPU you can pass through:
+
+- **Lane A — WSL2 + NVIDIA GPU passthrough.** Your Windows box *has* a
+  supported NVIDIA card. WSL2 gives you a real Linux userland with CUDA, so you
+  run the **full engine** inside WSL2 exactly like a native Linux rig.
+- **Lane B — no usable GPU.** No NVIDIA card (or a laptop iGPU). You run the
+  `sndr` CLI + GUI as a **remote client** and drive a Linux rig elsewhere,
+  exactly like a Mac.
+
+Pick your lane below.
+
+## Lane A — WSL2 + NVIDIA GPU passthrough
+
+This is the full local stack, running inside a WSL2 Linux distro.
+
+**Prerequisites (on Windows):**
+
+1. Recent NVIDIA Windows driver (the WSL CUDA passthrough is built into modern
+   drivers — do **not** install a separate CUDA driver *inside* WSL).
+2. WSL2 with a Linux distro (Ubuntu 24.04 recommended) and Docker with the
+   NVIDIA container toolkit inside that distro.
+3. Verify the GPU is visible inside WSL: `nvidia-smi` from the WSL shell must
+   list your card.
+
+**Then, inside the WSL2 shell, follow [`RUN_ON_LINUX.md`](RUN_ON_LINUX.md)
+verbatim** — it *is* Linux from here on:
+
+```bash
+curl -sSL https://raw.githubusercontent.com/Sandermage/sndr_core_engine/main/install.sh | bash
+sndr quickstart        # auto-detect GPU → fit a preset → download → boot → GUI
+```
+
+> **WSL2 quirk (handled for you).** WSL2's GPU stack needs a
+> `gptq_marlin_repack` environment override for the quantized-MoE kernels to
+> load correctly. `install.sh` **auto-detects WSL2 and writes that override**
+> for you — you don't set it by hand. If you install the plugin some other way,
+> this override is the one WSL-specific thing to carry over; see
+> [`TROUBLESHOOTING.md`](TROUBLESHOOTING.md).
+
+Everything else — presets, the one-heavy-model-at-a-time rule, `sndr down` as
+the safe stop — is identical to the Linux front door.
+
+## Lane B — no usable GPU (client mode)
+
+No NVIDIA card to pass through? Don't fight it — drive a Linux rig remotely,
+exactly like a Mac. Install the client profile and point it at the rig:
+
+```bash
+# in WSL2 or Git-Bash / PowerShell with the CLI installed (client profile)
+sndr remote setup http://<rig>:8102/v1
+sndr up --no-engine
+sndr chat
+```
+
+The three values that define client mode (the **remote-client triplet**):
+
+```bash
+SNDR_OPENAI_BASE_URL=http://<rig>:8102/v1
+SNDR_ENGINE_API_KEY=genesis-local
+GENESIS_MEMORY_DSN=postgresql://genesis:<pw>@<rig>:55432/genesis_memory   # optional
+```
+
+`<rig>` is the rig's hostname or LAN IP; the engine is keyed (`genesis-local`
+by default — a missing key surfaces as `401` / "no engine"). The full walk —
+where each value comes from, GUI vs CLI consumption, memory persistence, the
+`:8000` vs `:8102` port story — is [`REMOTE_ENGINE.md`](REMOTE_ENGINE.md), and
+the Mac page [`RUN_ON_MAC.md`](RUN_ON_MAC.md) covers the same client flow
+step-by-step.
+
+> **Shell env wins.** An exported shell variable overrides `.env` and the
+> value `sndr remote setup` saved. If a value won't take, check
+> `env | grep -E 'SNDR_|GENESIS_MEMORY'`.
+
+## Which lane am I in?
+
+| Situation | Lane |
+| --- | --- |
+| Desktop / workstation with a supported NVIDIA card | **A** — WSL2 + passthrough, follow [`RUN_ON_LINUX.md`](RUN_ON_LINUX.md) |
+| Laptop with only an integrated GPU, or no NVIDIA card | **B** — client mode, see [`REMOTE_ENGINE.md`](REMOTE_ENGINE.md) |
+| Have a separate Linux GPU box you want to use | **B** from Windows + [`RUN_ON_LINUX.md`](RUN_ON_LINUX.md) on the box |
+
+## See also
+
+- [`RUN_ON_LINUX.md`](RUN_ON_LINUX.md) — the full local stack (Lane A follows this).
+- [`REMOTE_ENGINE.md`](REMOTE_ENGINE.md) — the canonical client-mode reference (Lane B).
+- [`RUN_ON_MAC.md`](RUN_ON_MAC.md) — the same client flow, Mac-flavored.
+- [`TROUBLESHOOTING.md`](TROUBLESHOOTING.md) — WSL2 GPU visibility, `401`, kernel-load issues.

--- a/install.sh
+++ b/install.sh
@@ -64,6 +64,14 @@ GENESIS_NO_VERIFY="${GENESIS_NO_VERIFY:-0}"
 GENESIS_NO_PLUGIN_INSTALL="${GENESIS_NO_PLUGIN_INSTALL:-0}"
 GENESIS_BARE_METAL="${GENESIS_BARE_METAL:-0}"      # 1 = skip Docker hints, point operator at native vllm serve
 GENESIS_UNINSTALL=0
+# Client profile (Mac / Windows / no-GPU): install the CLI + GUI only and set
+# the operator up to DRIVE a remote rig — the engine cannot run here. Auto-
+# detected when no CUDA GPU is present; force with --client / --no-engine.
+GENESIS_CLIENT_PROFILE="${GENESIS_CLIENT_PROFILE:-0}"
+# Dry-run: exercise detection + the zero-config seams (.env scaffold, host.yaml
+# auto-init) WITHOUT any live clone / pip / engine launch. Used by the installer
+# test harness and for a safe preview.
+GENESIS_DRY_RUN="${GENESIS_DRY_RUN:-0}"
 
 PYTHON_BIN="${PYTHON_BIN:-python3}"
 # Pip flag overrides — accept both new SNDR_PIP_FLAGS and legacy
@@ -119,6 +127,8 @@ while [[ $# -gt 0 ]]; do
     --bare-metal) GENESIS_BARE_METAL=1; shift ;;
     --system) PIP_INSTALL_FLAGS=""; shift ;;
     --uninstall) GENESIS_UNINSTALL=1; shift ;;
+    --client|--no-engine) GENESIS_CLIENT_PROFILE=1; shift ;;
+    --dry-run) GENESIS_DRY_RUN=1; shift ;;
     -y|--yes) GENESIS_NON_INTERACTIVE=1; shift ;;
     -h|--help)
       cat <<'HELP_EOF'
@@ -155,6 +165,14 @@ Flags:
                        uvloop crash on PVE 8.x kernel 6.17.x — see
                        noonghunna/club-3090#49).
   --system             Use system pip (default: --user)
+  --client, --no-engine
+                       CLIENT PROFILE: install the CLI + GUI only and write a
+                       prefilled .env (Section B) so you can DRIVE a remote
+                       rig. The engine cannot run on a Mac / Windows / no-GPU
+                       host — auto-selected when no CUDA GPU is detected. See
+                       docs/RUN_ON_MAC.md.
+  --dry-run            Detect + exercise the zero-config seams (.env scaffold,
+                       host.yaml auto-init) with NO live clone / pip / launch.
   --uninstall          Remove Genesis and the entry-point plugin
   -y, --yes            Non-interactive (use defaults)
   -h, --help           Show this help
@@ -167,7 +185,9 @@ Examples:
 Env overrides (alternative to flags):
   GENESIS_REPO, GENESIS_HOME, GENESIS_PIN, GENESIS_WORKLOAD,
   GENESIS_MODELS_DIR, GENESIS_NON_INTERACTIVE, GENESIS_NO_VERIFY,
-  GENESIS_NO_PLUGIN_INSTALL, PYTHON_BIN, PIP_INSTALL_FLAGS
+  GENESIS_NO_PLUGIN_INSTALL, GENESIS_CLIENT_PROFILE, GENESIS_DRY_RUN,
+  SNDR_OPENAI_BASE_URL, SNDR_ENGINE_API_KEY, GENESIS_MEMORY_DSN,
+  PYTHON_BIN, PIP_INSTALL_FLAGS
 
 Author: Sandermage (Sander) Barzov Aleksandr, Ukraine, Odessa.
 HELP_EOF
@@ -444,8 +464,10 @@ pick_models_dir() {
 
   # Auto-detect candidate locations (only those that exist), de-duplicated.
   local candidates=() seen="" c
+  # ${HF_HOME:+...} yields "" when HF_HOME is unset/empty so `set -u` never
+  # trips and the empty candidate is skipped by the `[ -n "$c" ]` guard below.
   for c in \
-    "$HF_HOME/hub" \
+    "${HF_HOME:+$HF_HOME/hub}" \
     "$HOME/.cache/huggingface/hub" \
     "$HOME/models" \
     "/models" \
@@ -935,6 +957,156 @@ uninstall() {
   hint "To revert text-patches: pip uninstall vllm && pip install vllm  (re-install clean)"
 }
 
+# ─── Zero-config seams: client profile, .env scaffold, host auto-init ──
+#
+# These are ADDITIVE. The expert paths (pick_pin / pick_workload /
+# pick_models_dir / explicit --pin) are untouched — this layer only adds
+# sensible auto-defaults so the common case needs zero manual config.
+
+# Directory this script lives in (best-effort; curl|bash has no source file).
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" 2>/dev/null && pwd 2>/dev/null || echo "$PWD")"
+
+# Decide whether this host is a CLIENT (no engine) or a full stack. A CUDA
+# GPU is required for the engine; without one we drive a remote rig instead.
+# Honors an explicit --client / GENESIS_CLIENT_PROFILE. Relies on detect_gpu
+# having already run (N_GPUS / GPU_CLASS_HINT populated).
+detect_client_profile() {
+  step "Install profile"
+
+  if [ "$GENESIS_CLIENT_PROFILE" = "1" ]; then
+    ok "client profile (forced via --client / --no-engine)"
+    return
+  fi
+  # No nvidia-smi, or nvidia-smi saw zero GPUs → the engine cannot run here.
+  if ! command -v nvidia-smi >/dev/null 2>&1 || [ "${N_GPUS:-0}" = "0" ]; then
+    GENESIS_CLIENT_PROFILE=1
+    ok "client profile auto-selected (no CUDA GPU on this host)"
+    return
+  fi
+  ok "local full-stack profile (CUDA GPU present)"
+}
+
+# BREAK #4 — documented preflight reachability guard. Warn (never fatal) when
+# the clone URL is unreachable so the operator learns before a confusing
+# `git clone` failure. Skipped in dry-run.
+check_repo_reachable() {
+  [ "$GENESIS_DRY_RUN" = "1" ] && return 0
+  command -v git >/dev/null 2>&1 || return 0
+  if ! git ls-remote --exit-code --heads "$GENESIS_REPO" HEAD >/dev/null 2>&1; then
+    warn "clone URL may be unreachable: $GENESIS_REPO"
+    hint "check network / GENESIS_REPO; a 404 here means the clone step will fail"
+  fi
+}
+
+# Auto-copy the tracked .env.example → .env (Section A defaults) if the
+# operator has no .env yet. Idempotent (never overwrites an existing .env),
+# so a re-run is safe (DOWNLOAD-2). Writes .env NEXT TO the found template.
+ensure_local_env() {
+  local repo_dir="${1:-$GENESIS_HOME}"
+  local src="" cand
+  for cand in "$repo_dir/.env.example" "$SCRIPT_DIR/.env.example" "$PWD/.env.example"; do
+    if [ -f "$cand" ]; then src="$cand"; break; fi
+  done
+  if [ -z "$src" ]; then
+    warn ".env.example not found — skipping local .env scaffold"
+    return
+  fi
+  local dst
+  dst="$(cd "$(dirname "$src")" && pwd)/.env"
+  if [ -f "$dst" ]; then
+    ok ".env already present ($dst) — left untouched"
+    return
+  fi
+  cp "$src" "$dst"
+  ok "wrote $dst from .env.example (Section A auto-defaults — edit only to override)"
+}
+
+# First-run host.yaml auto-init (BREAK #2). Delegates to the CONFIG-owned
+# host_autoinit.ensure_host_yaml() so `sndr up` never resolves a launch mount
+# to a literal ${models_dir}. Non-fatal, non-TTY safe, idempotent.
+run_host_autoinit() {
+  step "Host paths auto-init (host.yaml)"
+  local out
+  if out=$(PYTHONPATH="${GENESIS_HOME}:${SCRIPT_DIR}:${PYTHONPATH:-}" \
+      "$PYTHON_BIN" -c 'from sndr.model_configs.host_autoinit import ensure_host_yaml; p = ensure_host_yaml(); print(p if p else "no-op (host.yaml present or nothing to detect)")' 2>/dev/null); then
+    ok "host.yaml auto-init: $out"
+  else
+    warn "host.yaml auto-init skipped (sndr not importable yet) — runs again on first launch"
+  fi
+}
+
+# Write a prefilled CLIENT .env (Section B triplet) so a Mac / Windows user
+# can drive a remote rig with zero further edits. Prompts for the rig URL
+# (default key genesis-local). Idempotent — never clobbers an existing .env.
+emit_client_env() {
+  local dst="${GENESIS_ENV_DIR:-$PWD}/.env"
+  if [ -f "$dst" ]; then
+    ok ".env already present ($dst) — left untouched (edit it to change the rig)"
+    return
+  fi
+
+  local rig_url="${SNDR_OPENAI_BASE_URL:-}"
+  if [ -z "$rig_url" ]; then
+    if [ "$GENESIS_NON_INTERACTIVE" = "1" ] || [ "$GENESIS_DRY_RUN" = "1" ] || [ ! -t 0 ]; then
+      rig_url="http://YOUR_RIG_HOST:8102/v1"
+    else
+      read -rp "  Rig engine URL [http://YOUR_RIG_HOST:8102/v1]: " rig_url
+      rig_url="${rig_url:-http://YOUR_RIG_HOST:8102/v1}"
+    fi
+  fi
+  local rig_key="${SNDR_ENGINE_API_KEY:-genesis-local}"
+  local mem_dsn="${GENESIS_MEMORY_DSN:-postgresql://genesis:genesis_mem_dev@YOUR_RIG_HOST:55432/genesis_memory}"
+
+  cat > "$dst" <<CLIENT_ENV_EOF
+# Genesis client .env — generated by install.sh (client profile).
+# This host has no CUDA GPU: the engine runs on a remote rig; the CLI + GUI
+# here drive it. Edit the three values below to point at your rig.
+# Read literally as KEY=VALUE (docker-compose semantics) — not sourced.
+SNDR_OPENAI_BASE_URL=${rig_url}
+SNDR_ENGINE_API_KEY=${rig_key}
+GENESIS_MEMORY_DSN=${mem_dsn}
+CLIENT_ENV_EOF
+  ok "wrote $dst (client Section B — rig=$rig_url, key=$rig_key)"
+}
+
+print_client_next_steps() {
+  step "Next steps (client)"
+  echo
+  ok "engine cannot run here; you are set up to drive a remote rig — see docs/RUN_ON_MAC.md"
+  echo
+  echo "  1) edit .env  → point SNDR_OPENAI_BASE_URL / key / DSN at your rig"
+  echo "  2) sndr up --no-engine     # start the CLI + Control Center GUI (:8765)"
+  echo "  3) curl \$SNDR_OPENAI_BASE_URL/models -H \"Authorization: Bearer \$SNDR_ENGINE_API_KEY\""
+  echo
+  echo "Docs: docs/RUN_ON_MAC.md"
+}
+
+# Full client-profile flow: emit .env(B), install CLI + GUI only (skip the
+# engine/plugin bits that cannot work without CUDA), print next steps.
+run_client_profile() {
+  step "Client install (CLI + GUI only — no engine)"
+  warn "no CUDA GPU on this host — installing the CLI + Control Center GUI to drive a remote rig"
+
+  emit_client_env
+
+  if [ "$GENESIS_DRY_RUN" = "1" ]; then
+    ok "dry-run: client CLI+GUI install skipped (clone/pip not run)"
+    print_client_next_steps
+    return
+  fi
+
+  # Real client install: the sndr package powers the CLI + GUI. We skip the
+  # engine bits (workload/models-dir pickers, launch-script generation, smoke
+  # verify) that require a local GPU + vLLM. The editable install still writes
+  # the vllm.general_plugins entry-point metadata, which is simply inert here.
+  check_repo_reachable
+  resolve_pin
+  clone_genesis
+  install_plugin      # editable install → `sndr` CLI + GUI importable
+  setup_pythonpath
+  print_client_next_steps
+}
+
 # ─── Main flow ────────────────────────────────────────────────────────
 
 main() {
@@ -950,16 +1122,41 @@ main() {
 
   preflight
   detect_gpu
+  detect_client_profile
+
+  # CLIENT PROFILE (Mac / Windows / no-GPU): CLI + GUI only, drive a remote rig.
+  if [ "$GENESIS_CLIENT_PROFILE" = "1" ]; then
+    run_client_profile
+    exit 0
+  fi
+
+  # LOCAL FULL STACK (Linux + CUDA).
   detect_vllm
   detect_proxmox_runtime
   pick_workload
   pick_models_dir
   resolve_pin
+
+  # DRY-RUN: exercise the zero-config seams without any live clone / pip /
+  # launch, then stop. Keeps the new flow test-harness-safe (HARD RULE 3).
+  if [ "$GENESIS_DRY_RUN" = "1" ]; then
+    check_repo_reachable
+    ensure_local_env "$GENESIS_HOME"
+    run_host_autoinit
+    ok "dry-run: local full-stack seams exercised (clone / pip / verify skipped)"
+    exit 0
+  fi
+
+  check_repo_reachable
   clone_genesis
   install_plugin
   setup_pythonpath
   generate_launch_script
   run_verify
+  # Zero-config close-out: auto-copy Section A .env + first-run host.yaml so
+  # `sndr up` needs no manual host.yaml / pin / port / key edits (BREAK #2).
+  ensure_local_env "$GENESIS_HOME"
+  run_host_autoinit
   print_next_steps
 }
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -60,6 +60,10 @@ nav:
   - Getting started:
       - Get started (2-min orientation): GETTING_STARTED.md
       - Quickstart (clone to chat): QUICKSTART.md
+      - Run on Linux (full stack): RUN_ON_LINUX.md
+      - Run on a Mac (client mode): RUN_ON_MAC.md
+      - Run on Windows / WSL2: RUN_ON_WINDOWS_WSL.md
+      - Remote engine (client mode): REMOTE_ENGINE.md
       - Install: INSTALL.md
       - Host setup (host.yaml): HOST_SETUP.md
       - Local AI primer: LOCAL_AI_PRIMER.md

--- a/scripts/security_scan.py
+++ b/scripts/security_scan.py
@@ -31,7 +31,6 @@ import subprocess
 import sys
 from pathlib import Path
 
-
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
 # Allowlist: paths whose content is acceptable to contain "sensitive-looking"
@@ -127,12 +126,22 @@ def check_no_private_keys(files: list[str]) -> list[str]:
     return [f"{h[0]}:{h[1]}: {h[2]}" for h in hits]
 
 
+# Secret-free `.env` *templates* are meant to be committed (they document the
+# knobs; the real `.env` stays ignored). Only these template suffixes are
+# waived — `.env`, `.env.local`, `.env.production`, etc. remain forbidden.
+_ENV_TEMPLATE_SUFFIXES: tuple[str, ...] = (
+    ".example", ".sample", ".template", ".dist",
+)
+
+
 def check_no_env_files(files: list[str]) -> list[str]:
-    """No .env or .env.* files committed."""
+    """No real .env / .env.* files committed (templates are allowed)."""
     bad = []
     for f in files:
         name = Path(f).name
-        if name == ".env" or name.startswith(".env."):
+        is_env = name == ".env" or name.startswith(".env.")
+        is_template = name.endswith(_ENV_TEMPLATE_SUFFIXES)
+        if is_env and not is_template:
             bad.append(f)
     return bad
 

--- a/scripts/start_sndr_client.sh
+++ b/scripts/start_sndr_client.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# Canonical CLIENT launcher (Mac / Windows / no-GPU) — drive a REMOTE rig.
+#
+# The engine (vLLM) cannot run on a host without a CUDA GPU. This launcher
+# starts the sndr CLI + Control Center GUI locally and points them at a remote
+# rig engine + memory. It mirrors scripts/start_sndr_daemon.sh's env discipline
+# (engine URL + key + DSN) for the client case — but runs `sndr up --no-engine`
+# natively instead of launching the vLLM container.
+#
+# Config precedence (docker-compose semantics): an exported shell var wins,
+# then ./.env (KEY=VALUE, read literally — NOT sourced), then these defaults.
+# The zero-friction path: `install.sh --client` writes a prefilled ./.env; run
+# this from that directory. See docs/RUN_ON_MAC.md.
+set -euo pipefail
+
+# Load ./.env literally (KEY=VALUE only; tolerate quotes / CRLF / comments)
+# WITHOUT sourcing it, so a stray shell metacharacter cannot execute.
+ENV_FILE="${SNDR_ENV_FILE:-.env}"
+if [ -f "$ENV_FILE" ]; then
+  while IFS= read -r line || [ -n "$line" ]; do
+    line="${line%$'\r'}"                       # strip CR (CRLF tolerance)
+    case "$line" in ''|'#'*) continue ;; esac  # skip blanks / comments
+    case "$line" in *=*) : ;; *) continue ;; esac
+    key="${line%%=*}"; val="${line#*=}"
+    key="${key#"${key%%[![:space:]]*}"}"       # ltrim key
+    key="${key%"${key##*[![:space:]]}"}"       # rtrim key
+    case "$key" in [A-Za-z_]*) : ;; *) continue ;; esac
+    val="${val%\"}"; val="${val#\"}"           # strip surrounding quotes
+    val="${val%\'}"; val="${val#\'}"
+    # Shell env wins: only set from .env when not already exported.
+    if [ -z "${!key:-}" ]; then export "$key=$val"; fi
+  done < "$ENV_FILE"
+fi
+
+# The remote-client triplet (the only genuinely manual surface).
+ENGINE_URL="${SNDR_OPENAI_BASE_URL:-http://YOUR_RIG_HOST:8102/v1}"
+ENGINE_KEY="${SNDR_ENGINE_API_KEY:-genesis-local}"
+MEM_DSN="${GENESIS_MEMORY_DSN:-}"
+GUI_PORT="${SNDR_GUI_PORT:-8765}"
+
+case "$ENGINE_URL" in
+  *YOUR_RIG_HOST*)
+    echo "warn: SNDR_OPENAI_BASE_URL still points at the placeholder YOUR_RIG_HOST" >&2
+    echo "      edit ./.env (or export SNDR_OPENAI_BASE_URL) to your rig, e.g." >&2
+    echo "      http://rig.local:8102/v1  — see docs/RUN_ON_MAC.md" >&2
+    ;;
+esac
+if [ -z "$MEM_DSN" ]; then
+  echo "note: GENESIS_MEMORY_DSN unset -> memory is ephemeral (empties on restart)." >&2
+  echo "      set it to your rig's pgvector DSN for durable memory." >&2
+fi
+
+export SNDR_OPENAI_BASE_URL="$ENGINE_URL"
+export SNDR_ENGINE_API_KEY="$ENGINE_KEY"
+export SNDR_GUI_PORT="$GUI_PORT"
+
+echo "sndr client -> engine=$ENGINE_URL, GUI=:$GUI_PORT (no local engine)"
+exec sndr up --no-engine "$@"

--- a/sndr/cli/commands/__init__.py
+++ b/sndr/cli/commands/__init__.py
@@ -21,6 +21,8 @@ from sndr.cli.commands.mem import (
 from sndr.cli.commands.pins import PinsListCommand
 from sndr.cli.commands.preflight import PreflightCommand
 from sndr.cli.commands.promoted import PROMOTED_COMMANDS
+from sndr.cli.commands.quickstart import QuickstartCommand
+from sndr.cli.commands.remote import RemoteSetupCommand
 from sndr.cli.commands.run import RunCommand
 from sndr.cli.commands.tui import TuiCommand
 from sndr.cli.commands.up import DownCommand, OpenCommand, UpCommand
@@ -65,6 +67,9 @@ def build_subparsers(subparsers: argparse._SubParsersAction) -> None:
     register(UpCommand())
     register(OpenCommand())
     register(DownCommand())
+    # UX GROUP-CLI: wizard-first zero-config front door + remote client mode.
+    register(QuickstartCommand())
+    register(RemoteSetupCommand())
     register(PinsListCommand())
     register(HealthCommand())
     register(PreflightCommand())

--- a/sndr/cli/commands/chat.py
+++ b/sndr/cli/commands/chat.py
@@ -19,7 +19,7 @@ Examples::
 """
 from __future__ import annotations
 
-import argparse
+import argparse  # noqa: TC003 — Namespace typing on the public execute() seam
 
 from sndr.cli._messages import Emitter
 
@@ -41,6 +41,10 @@ class ChatCommand:
             "--host", default="127.0.0.1",
             help="Engine host (default: 127.0.0.1).",
         )
+        parser.add_argument(
+            "--api-key", default=None,
+            help="Engine API key (else $SNDR_ENGINE_API_KEY when a remote is set).",
+        )
 
     def execute(self, args: argparse.Namespace) -> int:
         em = Emitter()  # advisory output → stderr
@@ -48,6 +52,19 @@ class ChatCommand:
         host = args.host
         port = args.port
         preset_id = args.preset
+        api_key = getattr(args, "api_key", None)
+
+        # Remote client mode (GAP 2): with no explicit host/port/preset, honor a
+        # configured remote engine (SNDR_OPENAI_BASE_URL) so a Mac/Windows client
+        # chats against the rig instead of the localhost:8000 default. Explicit
+        # --host / --port / preset still WIN (this branch is skipped for them).
+        if host == "127.0.0.1" and port is None and preset_id is None:
+            remote = _remote_from_env()
+            if remote is not None:
+                host, port, env_key = remote
+                if api_key is None:
+                    api_key = env_key
+
         if port is None:
             port = _port_for_preset(preset_id)
 
@@ -55,7 +72,7 @@ class ChatCommand:
         # of failing on the first turn.
         from sndr.product_api.legacy import engine_client
 
-        status = engine_client.engine_status(host, port=port, timeout=3.0)
+        status = engine_client.engine_status(host, port=port, timeout=3.0, api_key=api_key)
         if not status.get("reachable"):
             detail = status.get("error") or "no /health response"
             em.line(f"sndr chat: no engine reachable at {host}:{port} ({detail}).")
@@ -68,6 +85,28 @@ class ChatCommand:
         from sndr.cli.chat_repl import chat_loop
 
         return chat_loop(host, port, preset_id=preset_id)
+
+
+def _remote_from_env() -> tuple[str, int, str | None] | None:
+    """Parse (host, port, api_key) from the remote-engine env, or None.
+
+    Reads ``SNDR_OPENAI_BASE_URL`` (host/port) and ``SNDR_ENGINE_API_KEY``
+    (key). Returns None when no remote is configured or the URL is unparseable
+    (the caller then keeps the localhost default path)."""
+    import os
+    from urllib.parse import urlparse
+
+    base = os.environ.get("SNDR_OPENAI_BASE_URL", "").strip()
+    if not base:
+        return None
+    try:
+        parsed = urlparse(base)
+    except (ValueError, AttributeError):
+        return None
+    if not parsed.hostname or parsed.port is None:
+        return None
+    key = os.environ.get("SNDR_ENGINE_API_KEY", "").strip() or None
+    return parsed.hostname, int(parsed.port), key
 
 
 def _port_for_preset(preset_id: str | None) -> int:

--- a/sndr/cli/commands/quickstart.py
+++ b/sndr/cli/commands/quickstart.py
@@ -1,0 +1,363 @@
+# SPDX-License-Identifier: Apache-2.0
+"""CLI command: ``sndr quickstart`` — the zero-decision front door.
+
+The single command a newcomer runs after ``git clone``: it detects the rig +
+OS, resolves a FITTING preset through a progressive ladder, shows the per-card
+VRAM projection (with a hard FAIL gate BEFORE any container starts), and hands
+the actual bring-up to the EXISTING ``sndr up`` seams. It never reimplements an
+engine or a server — it is a thin, opinionated wrapper that removes decisions.
+
+Additive by construction: the expert path (``sndr launch <preset>``,
+``sndr up <preset>``, explicit pins) is untouched. ``quickstart`` only adds a
+simpler surface on top.
+
+Flow (every interactive step has a non-interactive escape — PICKER-2):
+
+  1. Detect OS + rig (``RigProbe`` / ``--fake-gpus`` / ``--rig``).
+  2. REMOTE PIVOT (GAP 3): no local GPU + ``SNDR_OPENAI_BASE_URL`` set -> client
+     mode (delegate to the daemon-only ``sndr up --no-engine`` path). No GPU and
+     no remote -> the actionable ``sndr remote setup`` hint (never a bare "no
+     preset fits").
+  3. Preset LADDER (PICKER-3 / DEFAULT-3): explicit arg > pinned default
+     (validated) > top-fit. Exactly one fit -> auto; many + TTY -> one-key
+     confirm of the top fit; non-TTY / ``--no-input`` -> top fit, never stdin.
+  4. VRAM PROJECTION (VRAM-1): print the per-card budget for the chosen preset;
+     a FAIL verdict refuses BEFORE boot unless ``--force``.
+  5. BOOT: delegate to the existing ``sndr up`` flow (weights -> engine -> ready
+     -> daemon -> GUI).
+  6. Post-boot (DEFAULT-1): after a green boot, offer to pin the preset as the
+     default (opt-IN, only when interactive).
+
+Examples::
+
+    sndr quickstart                       # detect rig -> pick + boot -> GUI
+    sndr quickstart prod-qwen3.6-35b-balanced
+    sndr quickstart --no-input            # CI / scripted, never prompts
+    sndr quickstart --fake-gpus "RTX A5000:24564:8.6;RTX A5000:24564:8.6" --dry-run
+"""
+from __future__ import annotations
+
+import argparse
+import platform
+import sys
+from typing import Any
+
+from sndr.cli import user_prefs
+from sndr.cli._messages import Emitter
+
+_DEFAULT_GUI_PORT = 8765
+_REMOTE_ENV = "SNDR_OPENAI_BASE_URL"
+
+
+class QuickstartCommand:
+    name = "quickstart"
+    help = "Zero-config bring-up: detect your rig, pick + boot a fitting preset, open the GUI."
+
+    def configure_parser(self, parser: argparse.ArgumentParser) -> None:
+        parser.add_argument(
+            "preset", nargs="?", default=None,
+            help="Preset to boot. Omit to auto-pick (pinned default, else the "
+                 "top-ranked fitting preset for the detected rig).",
+        )
+        parser.add_argument(
+            "--no-input", action="store_true",
+            help="Headless: never prompt on stdin (auto-pick, skip the "
+                 "make-default offer).",
+        )
+        parser.add_argument(
+            "--force", action="store_true",
+            help="Boot even when the VRAM projection says the preset will not "
+                 "fit (override the FAIL gate).",
+        )
+        parser.add_argument(
+            "--gui-port", type=int, default=_DEFAULT_GUI_PORT, metavar="PORT",
+            help=f"Port for the product-API + GUI daemon (default: {_DEFAULT_GUI_PORT}).",
+        )
+        parser.add_argument(
+            "--dry-run", action="store_true",
+            help="Resolve + project + plan without starting anything.",
+        )
+        parser.add_argument(
+            "--rig", default=None, metavar="HARDWARE_ID",
+            help="Resolve the fit against a builtin hardware def (offline).",
+        )
+        parser.add_argument(
+            "--fake-gpus", default=None, metavar="SPEC",
+            help="Resolve the fit against a synthetic rig "
+                 "'name:vram_mib:cc;...' (offline).",
+        )
+
+    # ── dispatch ─────────────────────────────────────────────────────────────
+
+    def execute(self, args: argparse.Namespace) -> int:  # noqa: PLR0911 — linear front-door ladder: one early-return per stage (remote/ladder/projection/dry-run/boot)
+        em = Emitter()  # advisory output → stderr (stdout stays scriptable)
+        no_input = bool(getattr(args, "no_input", False))
+        gui_port = int(getattr(args, "gui_port", _DEFAULT_GUI_PORT))
+
+        os_name = platform.system() or "unknown"
+        rig = _detect_rig(args)
+
+        em.blank()
+        em.line(f"  sndr quickstart — OS {os_name}, "
+                f"{rig.gpu_count} GPU(s) detected ({rig.source})")
+
+        # ── 2) remote pivot (no local GPU) ───────────────────────────────────
+        remote_url = _remote_env_url()
+        if rig.gpu_count == 0:
+            if remote_url:
+                em.line(f"  no local GPU — client mode against {remote_url}")
+                em.line("  bringing up the daemon + GUI pointed at the remote …")
+                ns = _up_namespace(preset=None, gui_port=gui_port, no_engine=True)
+                return _boot(ns)
+            em.err("no local GPU detected and no remote engine configured.")
+            em.hint("point this machine at a rig:  sndr remote setup http://<rig>:8102/v1")
+            em.hint("or see docs/REMOTE_ENGINE.md for client-mode setup")
+            return 2
+
+        # ── 3) preset ladder ─────────────────────────────────────────────────
+        try:
+            chosen, why = _resolve_preset(args, rig, em, no_input=no_input)
+        except _NoFitError as exc:
+            em.err(str(exc))
+            em.hint("pick one interactively:  sndr")
+            em.hint("or see docs/SINGLE_CARD.md for single-card options")
+            return 2
+        em.line(f"  preset: {chosen}   ({why})")
+
+        # ── 4) VRAM projection + hard FAIL gate ──────────────────────────────
+        projection = _project_vram(chosen, rig)
+        if projection is not None:
+            _print_projection(em, chosen, rig, projection)
+            if getattr(projection, "verdict", None) == "FAIL" and not args.force:
+                em.err(f"projection says {chosen} will not fit on your rig — "
+                       "refusing to boot.")
+                em.hint("override with --force, or pick a lighter preset: sndr")
+                return 2
+
+        # ── dry-run: report the plan, start nothing ──────────────────────────
+        if args.dry_run:
+            url = f"http://127.0.0.1:{gui_port}"
+            em.line("  (dry-run) plan:")
+            em.line(f"    1. sndr up {chosen}   (weights → engine → ready)")
+            em.line(f"    2. start product-API + GUI   ({url})")
+            print(f"sndr quickstart plan: {chosen} gui={url}")
+            return 0
+
+        # ── 5) boot via the existing `sndr up` flow ──────────────────────────
+        ns = _up_namespace(preset=chosen, gui_port=gui_port, no_engine=False)
+        rc = _boot(ns)
+        if rc != 0:
+            return rc
+
+        # ── 6) post-boot: offer to pin the default (opt-in, interactive only) ─
+        if not no_input:
+            _maybe_offer_set_default(chosen, no_input=no_input)
+        return 0
+
+
+# ── resolution ───────────────────────────────────────────────────────────────
+
+
+class _NoFitError(Exception):
+    """No preset fits the rig and none was named."""
+
+
+def _resolve_preset(
+    args: argparse.Namespace, rig, em: Emitter, *, no_input: bool,
+) -> tuple[str, str]:
+    """Resolve (preset_id, reason) via the ladder: explicit > pinned > top-fit.
+
+    Raises :class:`_NoFitError` when nothing fits and no preset was named.
+    """
+    if args.preset:
+        return str(args.preset), "explicit"
+
+    pinned = user_prefs.get_default_preset()
+    if pinned:
+        return pinned, "your pinned default"
+
+    fitting = _fitting_presets(rig)
+    if not fitting:
+        raise _NoFitError("no preset fits this rig")
+    if len(fitting) == 1:
+        em.line(f"  using the only fitting preset: {fitting[0]}")
+        return fitting[0], "only fit"
+
+    top = fitting[0]
+    # Many fit — confirm the top pick when interactive; otherwise take it.
+    if not no_input and _is_tty():
+        gpu_label = _rig_label(rig)
+        if _prompt(em, f"Launch {top} for your {gpu_label}? [Y/n]", default=True):
+            return top, "confirmed top fit"
+        raise _NoFitError("declined the top fit")
+    return top, "top fit"
+
+
+def _fitting_presets(rig) -> list[str]:
+    """The rig-fitting presets, best-first (the same ranking the wizard shows)."""
+    from sndr.cli.wizard.launch_wizard import build_catalog
+    from sndr.model_configs.registry_v2 import (
+        list_presets,
+        load_alias,
+        load_preset_def,
+    )
+
+    catalog = build_catalog(
+        rig, preset_ids=list_presets(),
+        card_loader=load_preset_def, cfg_loader=load_alias,
+    )
+    return [c.preset_id for c in catalog.menu(show_all=False)]
+
+
+def _rig_label(rig) -> str:
+    if not getattr(rig, "gpus", None):
+        return "rig"
+    name = rig.gpus[0].name
+    return f"{rig.gpu_count}x {name}" if rig.gpu_count > 1 else name
+
+
+# ── VRAM projection ──────────────────────────────────────────────────────────
+
+
+def _project_vram(preset_id: str, rig) -> Any | None:
+    """Project the preset's per-card VRAM against the rig (reuse the byte-level
+    KV projector). Returns a ``Projection`` or None when the model declares no
+    byte-level shape (the gate then simply skips)."""
+    from sndr.cli.commands.kv_calc import _precise_vram_gib
+    from sndr.model_configs import kv_projector as kp
+    from sndr.model_configs.registry_v2 import load_alias, load_model, load_preset_def
+
+    try:
+        cfg = load_alias(preset_id)
+        preset_def = load_preset_def(preset_id)
+        model_def = load_model(preset_def.model)
+    except Exception:  # noqa: BLE001 — an unresolvable preset skips the gate
+        return None
+
+    shape = getattr(model_def.capabilities, "shape", None)
+    if shape is None or getattr(shape, "num_attention_layers", None) is None:
+        return None
+
+    vram_gib = _precise_vram_gib(rig)
+    if vram_gib is None:
+        return None
+    try:
+        return kp.project(
+            cfg,
+            kp.ProjectorRig(vram_gib_per_card=vram_gib, gpu_count=1, name=rig.source),
+            shape=shape,
+            preset_id=preset_id,
+        )
+    except ValueError:
+        return None
+
+
+def _print_projection(em: Emitter, preset_id: str, rig, p) -> None:
+    budget = getattr(p, "budget_gib", 0.0) or 0.0
+    total = getattr(p, "total_gib", 0.0) or 0.0
+    pct = (100.0 * total / budget) if budget else 0.0
+    em.line(f"  VRAM projection — {preset_id} on {_rig_label(rig)} (per card):")
+    em.line(f"    weights (÷TP)   {getattr(p, 'weights_gib', 0.0):.2f} GiB")
+    em.line(f"    KV pool         {getattr(p, 'kv_pool_actual_gib', 0.0):.2f} GiB")
+    em.line(f"    peak total      {total:.2f} / {budget:.2f} GiB budget "
+            f"({pct:.0f}%)  → {getattr(p, 'verdict', '?')}")
+
+
+# ── interactive helpers ──────────────────────────────────────────────────────
+
+
+def _is_tty() -> bool:
+    try:
+        return bool(sys.stdin.isatty() and sys.stdout.isatty())
+    except Exception:  # noqa: BLE001 — a detached stream is simply not a TTY
+        return False
+
+
+def _prompt(em: Emitter, question: str, *, default: bool, tty_required: bool = True) -> bool:
+    """A minimal yes/no prompt that returns ``default`` on EOF / non-TTY instead
+    of hanging (PICKER-2 graceful EOF). ``default`` is the value chosen when the
+    operator just hits Enter (or when non-interactive)."""
+    if tty_required and not _is_tty():
+        return default
+    try:
+        answer = input(f"  {question} ").strip().lower()
+    except EOFError:
+        em.line("    (no interactive input — using the default; "
+                "pass --no-input to silence)")
+        return default
+    if not answer:
+        return default
+    return answer in ("y", "yes")
+
+
+def _maybe_offer_set_default(preset_id: str, *, no_input: bool = False) -> None:
+    """After a green boot, offer to pin ``preset_id`` as the default (DEFAULT-1,
+    opt-IN, N-default). No-op when non-interactive, ``--no-input``, or already
+    pinned to this preset."""
+    if no_input or not _is_tty():
+        return
+    if user_prefs.get_default_preset() == preset_id:
+        return
+    em = Emitter()
+    if _prompt(em, f"Make {preset_id} your default? [y/N]", default=False):
+        try:
+            user_prefs.set_default_preset(preset_id)
+            em.ok(f"default set — future `sndr quickstart` will boot {preset_id}")
+        except ValueError:
+            pass
+
+
+# ── rig detection + boot seams (mocked in tests) ─────────────────────────────
+
+
+def _detect_rig(args: argparse.Namespace):
+    """Detect the rig: ``--fake-gpus`` > ``--rig`` > live ``nvidia-smi`` probe."""
+    from sndr.model_configs.preflight_fit import (
+        RigProbe,
+        rig_from_fake_spec,
+        rig_from_hardware_def,
+    )
+
+    fake = getattr(args, "fake_gpus", None)
+    rig_id = getattr(args, "rig", None)
+    if fake is not None:
+        return rig_from_fake_spec(fake)
+    if rig_id is not None:
+        from sndr.model_configs.registry_v2 import load_hardware
+
+        return rig_from_hardware_def(load_hardware(rig_id), source=f"rig:{rig_id}")
+    return RigProbe().detect()
+
+
+def _remote_env_url() -> str | None:
+    import os
+
+    url = os.environ.get(_REMOTE_ENV, "").strip()
+    return url or None
+
+
+def _up_namespace(*, preset: str | None, gui_port: int, no_engine: bool) -> argparse.Namespace:
+    """Build the ``sndr up`` argument namespace. ``no_input=True`` so ``up`` never
+    prompts (the wizard owns all prompting)."""
+    return argparse.Namespace(
+        preset=preset,
+        port=None,
+        gui_port=gui_port,
+        no_engine=no_engine,
+        dry_run=False,
+        no_input=True,
+        timeout=300,
+        rig=None,
+        fake_gpus=None,
+        output="text",
+    )
+
+
+def _boot(ns: argparse.Namespace) -> int:
+    """Delegate the actual bring-up to the EXISTING ``sndr up`` flow."""
+    from sndr.cli.commands.up import UpCommand
+
+    return UpCommand().execute(ns)
+
+
+__all__ = ["QuickstartCommand"]

--- a/sndr/cli/commands/quickstart.py
+++ b/sndr/cli/commands/quickstart.py
@@ -162,6 +162,32 @@ class _NoFitError(Exception):
     """No preset fits the rig and none was named."""
 
 
+def _lone_user_first(fitting: list[str]) -> list[str]:
+    """If the top auto-pick is a peak-throughput ``-multiconc`` preset, promote
+    its SAME-MODEL single-stream sibling to the front instead.
+
+    The fit ranking sorts by measured metric desc, which floats ``-multiconc``
+    (max_num_seqs=8, ~100% per-card VRAM) above its balanced sibling. A
+    zero-decision newcomer gets no benefit from multiconc but takes its OOM
+    risk, so for the auto-default we prefer the same model's single-stream
+    variant when it also fits. Surgical by design: only swaps a multiconc leader
+    for its own sibling — the model choice and cross-model order are untouched,
+    and nothing is dropped (if only the multiconc variant fits, it stays). The
+    interactive full menu (different code path) is unaffected.
+    """
+    if not fitting:
+        return fitting
+    top = fitting[0]
+    if "multiconc" not in top.lower():
+        return fitting
+    stem = top.lower().replace("-multiconc", "")
+    for pid in fitting[1:]:
+        low = pid.lower()
+        if low.startswith(stem) and "multiconc" not in low:
+            return [pid] + [x for x in fitting if x != pid]
+    return fitting
+
+
 def _resolve_preset(
     args: argparse.Namespace, rig, em: Emitter, *, no_input: bool,
 ) -> tuple[str, str]:
@@ -176,7 +202,7 @@ def _resolve_preset(
     if pinned:
         return pinned, "your pinned default"
 
-    fitting = _fitting_presets(rig)
+    fitting = _lone_user_first(_fitting_presets(rig))
     if not fitting:
         raise _NoFitError("no preset fits this rig")
     if len(fitting) == 1:

--- a/sndr/cli/commands/remote.py
+++ b/sndr/cli/commands/remote.py
@@ -1,0 +1,183 @@
+# SPDX-License-Identifier: Apache-2.0
+"""CLI command: ``sndr remote setup <url>`` — client-mode onboarding (GAP 1).
+
+The engine needs Linux + CUDA, so Mac/Windows operators drive the ``sndr`` CLI
+and the Control Center GUI against a REMOTE rig engine. This command configures
+THIS machine to do that in one line: it validates the base URL, probes the
+remote (best-effort), remembers the choice, and prints the three canonical
+exports the rest of the stack reads.
+
+  sndr remote setup http://192.168.1.10:8102/v1 --key genesis-local
+
+  * URL is validated to the ``http(s)://host:port/v1`` form — a bad URL is a
+    loud typed refusal (GUARD-1, exit 64 / ``EX_USAGE``), never a silent
+    misconfig.
+  * Reachability is probed best-effort — an unreachable rig WARNS but still
+    prints the exports (you may be setting up before the rig is on).
+  * The choice is cached via :mod:`sndr.cli.user_prefs` (DEFAULT-4); with
+    ``--write-env`` the remote block is also written to ``./.env``.
+  * The three exports (``SNDR_OPENAI_BASE_URL`` / ``SNDR_ENGINE_API_KEY`` /
+    ``GENESIS_MEMORY_DSN``) are printed with a "shell env wins" note. When the
+    memory DSN is not reachable, the command says so out loud instead of
+    letting the daemon fall back silently to ephemeral in-memory storage.
+"""
+from __future__ import annotations
+
+import argparse  # noqa: TC003 — Namespace typing on the public execute() seam
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+from sndr.cli import user_prefs
+from sndr.cli._messages import Emitter
+
+_EX_USAGE = 64  # BSD sysexits.h — a usage/typed-refusal error
+_DEFAULT_KEY = "genesis-local"
+
+
+class RemoteSetupCommand:
+    name = "remote"
+    help = "Configure this machine to drive a remote rig engine (Mac/Windows client mode)."
+
+    def configure_parser(self, parser: argparse.ArgumentParser) -> None:
+        sub = parser.add_subparsers(dest="remote_cmd", metavar="SUBCOMMAND")
+        setup = sub.add_parser(
+            "setup", help="Point this machine at a remote rig engine URL.",
+        )
+        setup.add_argument(
+            "url", help="Remote engine base URL, e.g. http://192.168.1.10:8102/v1",
+        )
+        setup.add_argument(
+            "--key", default=_DEFAULT_KEY, metavar="API_KEY",
+            help=f"Engine API key for the remote (default: {_DEFAULT_KEY}).",
+        )
+        setup.add_argument(
+            "--dsn", default=None, metavar="PGVECTOR_DSN",
+            help="Postgres+pgvector DSN for persistent neural-graph memory.",
+        )
+        setup.add_argument(
+            "--write-env", action="store_true",
+            help="Also write the remote block to ./.env (save-my-choice).",
+        )
+
+    def execute(self, args: argparse.Namespace) -> int:
+        em = Emitter()  # advisory output → stderr (stdout carries the exports)
+
+        if getattr(args, "remote_cmd", None) != "setup":
+            em.err("usage: sndr remote setup <url> [--key ...] [--dsn ...] [--write-env]")
+            return _EX_USAGE
+
+        url = str(getattr(args, "url", "") or "").strip()
+        parsed = _validate_url(url)
+        if parsed is None:
+            em.err(f"not a valid engine URL: {url!r}")
+            em.hint("expected form:  http(s)://<host>:<port>/v1")
+            em.hint("example:        sndr remote setup http://192.168.1.10:8102/v1")
+            return _EX_USAGE
+
+        host, port = parsed
+        key = str(getattr(args, "key", None) or _DEFAULT_KEY)
+        dsn = getattr(args, "dsn", None)
+
+        # Probe reachability — best-effort; warn (do not fail) so the exports
+        # print even when the rig is not up yet.
+        em.blank()
+        status = _probe_remote(host, port, key)
+        if status.get("reachable"):
+            em.ok(f"remote engine reachable at {host}:{port}")
+        else:
+            detail = status.get("error") or "no /health response"
+            em.err(f"remote engine not reachable at {host}:{port} ({detail}) — "
+                   "printing the exports anyway.")
+
+        # Persist the choice (DEFAULT-4 caching).
+        user_prefs.set_last_remote(url, key=key, dsn=dsn)
+
+        # Optionally write ./.env (save-my-choice ladder).
+        if getattr(args, "write_env", False):
+            written = _write_dotenv(url, key, dsn)
+            em.line(f"  wrote remote block to {written}")
+
+        # The three canonical exports (stdout — scriptable / copy-paste).
+        em.blank()
+        em.line("  add these to your shell (shell env WINS over the prefs file):")
+        print(f"export SNDR_OPENAI_BASE_URL={url}")
+        print(f"export SNDR_ENGINE_API_KEY={key}")
+        if dsn:
+            print(f"export GENESIS_MEMORY_DSN={dsn}")
+        else:
+            print("# GENESIS_MEMORY_DSN=  (unset → ephemeral in-memory memory; "
+                  "set a pgvector DSN to persist)")
+        return 0
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+
+def _validate_url(url: str) -> tuple[str, int] | None:  # noqa: PLR0911 — one early-return per URL-form guard reads clearer than a compound boolean
+
+    """Validate the ``http(s)://host:port/v1`` form and return (host, port).
+
+    Returns None on any malformed URL (missing scheme/host/port or non-/v1
+    path) so the caller can issue a typed refusal.
+    """
+    if not url:
+        return None
+    try:
+        parsed = urlparse(url)
+    except (ValueError, AttributeError):
+        return None
+    if parsed.scheme not in ("http", "https"):
+        return None
+    if not parsed.hostname:
+        return None
+    port = parsed.port
+    if port is None:
+        return None
+    if parsed.path.rstrip("/") and not parsed.path.rstrip("/").endswith("/v1"):
+        return None
+    return parsed.hostname, int(port)
+
+
+def _probe_remote(host: str, port: int, key: str | None) -> dict[str, Any]:
+    """Best-effort ``/health`` probe of the remote engine (mocked in tests)."""
+    try:
+        from sndr.product_api.legacy import engine_client
+
+        return engine_client.engine_status(host, port=port, timeout=3.0, api_key=key)
+    except Exception as exc:  # noqa: BLE001 — a probe failure is non-fatal here
+        return {"reachable": False, "error": f"{type(exc).__name__}: {exc}"}
+
+
+def _write_dotenv(url: str, key: str, dsn: str | None) -> Path:
+    """Append/refresh the remote block in ``./.env`` and return its path.
+
+    Self-contained (does not read the CONFIG group's ``.env.example``) so the
+    two file groups stay disjoint; the block below mirrors that template's
+    remote section.
+    """
+    path = Path.cwd() / ".env"
+    existing = ""
+    if path.is_file():
+        existing = path.read_text(encoding="utf-8")
+
+    block_lines = [
+        "# --- sndr remote (client mode) ---",
+        f"SNDR_OPENAI_BASE_URL={url}",
+        f"SNDR_ENGINE_API_KEY={key}",
+    ]
+    if dsn:
+        block_lines.append(f"GENESIS_MEMORY_DSN={dsn}")
+    block = "\n".join(block_lines) + "\n"
+
+    # Drop any prior lines we own, then append a fresh block (idempotent-ish).
+    owned = ("SNDR_OPENAI_BASE_URL=", "SNDR_ENGINE_API_KEY=", "GENESIS_MEMORY_DSN=",
+             "# --- sndr remote (client mode) ---")
+    kept = [ln for ln in existing.splitlines() if not ln.startswith(owned)]
+    body = "\n".join(kept).rstrip("\n")
+    text = (body + "\n\n" if body else "") + block
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+__all__ = ["RemoteSetupCommand"]

--- a/sndr/cli/commands/remote.py
+++ b/sndr/cli/commands/remote.py
@@ -7,7 +7,7 @@ THIS machine to do that in one line: it validates the base URL, probes the
 remote (best-effort), remembers the choice, and prints the three canonical
 exports the rest of the stack reads.
 
-  sndr remote setup http://192.168.1.10:8102/v1 --key genesis-local
+  sndr remote setup http://<your-host>:8102/v1 --key genesis-local
 
   * URL is validated to the ``http(s)://host:port/v1`` form — a bad URL is a
     loud typed refusal (GUARD-1, exit 64 / ``EX_USAGE``), never a silent
@@ -45,7 +45,7 @@ class RemoteSetupCommand:
             "setup", help="Point this machine at a remote rig engine URL.",
         )
         setup.add_argument(
-            "url", help="Remote engine base URL, e.g. http://192.168.1.10:8102/v1",
+            "url", help="Remote engine base URL, e.g. http://<your-host>:8102/v1",
         )
         setup.add_argument(
             "--key", default=_DEFAULT_KEY, metavar="API_KEY",
@@ -72,7 +72,7 @@ class RemoteSetupCommand:
         if parsed is None:
             em.err(f"not a valid engine URL: {url!r}")
             em.hint("expected form:  http(s)://<host>:<port>/v1")
-            em.hint("example:        sndr remote setup http://192.168.1.10:8102/v1")
+            em.hint("example:        sndr remote setup http://<your-host>:8102/v1")
             return _EX_USAGE
 
         host, port = parsed

--- a/sndr/cli/commands/run.py
+++ b/sndr/cli/commands/run.py
@@ -42,9 +42,12 @@ from __future__ import annotations
 import argparse
 import sys
 import time
-from collections.abc import Callable
+from collections.abc import (
+    Callable,  # noqa: TC003 — on_progress callback type, kept importable
+)
 from typing import Any
 
+from sndr.cli import user_prefs
 from sndr.cli._messages import Emitter, heartbeat
 
 _DEFAULT_TIMEOUT_S = 300
@@ -90,17 +93,29 @@ class RunCommand:
 
     # ── dispatch ─────────────────────────────────────────────────────────────
 
-    def execute(self, args: argparse.Namespace) -> int:
+    def execute(self, args: argparse.Namespace) -> int:  # noqa: PLR0911, PLR0915 — linear cold-start ladder: one early-return per stage (resolve/pull/launch/wait/chat)
         em = Emitter()  # advisory output → stderr (stdout stays scriptable)
 
-        # 1) Resolve the preset (explicit, else top-fit for the rig).
+        # 1) Resolve the preset (explicit > pinned default > top-fit for the rig).
+        preset_arg = args.preset
+        if preset_arg is None:
+            pinned = user_prefs.get_default_preset()
+            if pinned:
+                preset_arg = pinned
         try:
             preset_id, port = _resolve_preset_and_port(
-                args.preset, rig_id=args.rig, fake_gpus=args.fake_gpus,
+                preset_arg, rig_id=args.rig, fake_gpus=args.fake_gpus,
                 port_override=args.port,
             )
         except _ResolveError as exc:
             em.line(f"sndr run: {exc}")
+            # Remote pivot pointer: an empty local rig with a configured remote
+            # engine chats against the remote — point there instead of dead-ending.
+            import os as _os
+
+            if _os.environ.get("SNDR_OPENAI_BASE_URL", "").strip():
+                em.line("  local rig empty but SNDR_OPENAI_BASE_URL set — "
+                        "chat against the remote with: sndr chat")
             em.line("  list presets: sndr preset list   |   pick interactively: sndr")
             return 2
 
@@ -291,7 +306,7 @@ def _launch_detached(
         argv.append("--dry-run")
     redirect = {"stdout": subprocess.DEVNULL, "stderr": subprocess.DEVNULL} if quiet else {}
     try:
-        completed = subprocess.run(argv, **redirect)
+        completed = subprocess.run(argv, check=False, **redirect)
         return completed.returncode
     except FileNotFoundError:
         # `python -m sndr` unavailable (no console entry on PATH) — fall back to

--- a/sndr/cli/commands/up.py
+++ b/sndr/cli/commands/up.py
@@ -48,12 +48,15 @@ Examples::
 """
 from __future__ import annotations
 
-import argparse
+import argparse  # noqa: TC003 — used at runtime for Namespace typing on public seams
 import sys
 import time
-from collections.abc import Callable
+from collections.abc import (
+    Callable,  # noqa: TC003 — on_progress callback type, kept importable
+)
 from typing import Any
 
+from sndr.cli import user_prefs
 from sndr.cli._messages import Emitter, heartbeat
 
 _DEFAULT_GUI_PORT = 8765
@@ -116,7 +119,7 @@ class UpCommand:
                  "'name:vram_mib:cc;...' (offline).",
         )
 
-    def execute(self, args: argparse.Namespace) -> int:
+    def execute(self, args: argparse.Namespace) -> int:  # noqa: PLR0911, PLR0912, PLR0915 — linear bring-up ladder: one early-return per failure stage (weights/launch/ready/daemon) reads clearer than extraction
         em = Emitter()  # advisory output → stderr (stdout stays scriptable)
 
         gui_port = int(getattr(args, "gui_port", _DEFAULT_GUI_PORT))
@@ -129,15 +132,35 @@ class UpCommand:
         if not no_engine:
             from sndr.cli.commands.run import _resolve_preset_and_port, _ResolveError
 
+            # Preset ladder (additive): a pinned default wins over the top-fit
+            # when no preset was named (validated; falls through to top-fit on a
+            # miss). The existing top-fit stays the fallback.
+            preset_arg = args.preset
+            if preset_arg is None:
+                pinned = user_prefs.get_default_preset()
+                if pinned:
+                    preset_arg = pinned
+
             try:
                 preset_id, engine_port = _resolve_preset_and_port(
-                    args.preset, rig_id=args.rig, fake_gpus=args.fake_gpus,
+                    preset_arg, rig_id=args.rig, fake_gpus=args.fake_gpus,
                     port_override=args.port,
                 )
             except _ResolveError as exc:
-                em.line(f"sndr up: {exc}")
-                em.line("  list presets: sndr preset list   |   pick interactively: sndr")
-                return 2
+                # Remote pivot (GAP 3): an empty local rig with a configured
+                # remote engine is client mode — bring up the daemon-only path
+                # instead of failing. Only when no remote is set do we keep the
+                # existing return-2 + hint.
+                if _remote_configured():
+                    em.line("  no fitting local rig — client mode against "
+                            f"{_remote_url()}")
+                    no_engine = True
+                    preset_id = None
+                    engine_port = None
+                else:
+                    em.line(f"sndr up: {exc}")
+                    em.line("  list presets: sndr preset list   |   pick interactively: sndr")
+                    return 2
 
         em.blank()
         if no_engine:
@@ -170,7 +193,7 @@ class UpCommand:
 
         # ── 1) engine: ensure weights → launch + wait (skipped with --no-engine) ──
         if not no_engine:
-            assert preset_id is not None and engine_port is not None
+            assert preset_id is not None and engine_port is not None  # noqa: PT018 — one invariant on the resolved pair, not a test assertion
             # Download the model first (no-op when already complete) so the GUI
             # path is as turnkey as `sndr run` — otherwise the container would
             # block on a slow in-container HF pull with no CLI progress.
@@ -226,6 +249,12 @@ class UpCommand:
             em.hint(f"chat from the terminal instead:  sndr chat {preset_id}")
         em.hint("stop everything:                 sndr down"
                 + (f" {preset_id}" if not no_engine and preset_id and not str(preset_id).startswith("prod-") else ""))
+
+        # Post-boot default offer (DEFAULT-1, opt-in). Guarded by --no-input at
+        # the call site; the seam itself no-ops on a non-TTY / already-pinned
+        # preset, so scripted callers and existing tests are unaffected.
+        if not no_engine and preset_id and not bool(getattr(args, "no_input", False)):
+            _maybe_offer_set_default(preset_id)
         return 0
 
 
@@ -328,6 +357,48 @@ class DownCommand:
         return 0
 
 
+# ── remote / default seams (mocked in tests) ─────────────────────────────────
+
+
+def _remote_url() -> str:
+    """The configured remote engine URL (``SNDR_OPENAI_BASE_URL``), or ""."""
+    import os
+
+    return os.environ.get("SNDR_OPENAI_BASE_URL", "").strip()
+
+
+def _remote_configured() -> bool:
+    """True when this machine is pointed at a remote engine (client mode)."""
+    return bool(_remote_url())
+
+
+def _maybe_offer_set_default(preset_id: str) -> None:
+    """After a green boot, offer to pin ``preset_id`` as the default (DEFAULT-1,
+    opt-IN). No-op on a non-TTY or when already pinned to this preset — safe to
+    call unconditionally from the success path."""
+    import sys
+
+    try:
+        interactive = bool(sys.stdin.isatty() and sys.stdout.isatty())
+    except Exception:  # noqa: BLE001 — a detached stream is simply not a TTY
+        interactive = False
+    if not interactive:
+        return
+    if user_prefs.get_default_preset() == preset_id:
+        return
+    em = Emitter()
+    try:
+        answer = input(f"  Make {preset_id} your default? [y/N] ").strip().lower()
+    except EOFError:
+        return
+    if answer in ("y", "yes"):
+        try:
+            user_prefs.set_default_preset(preset_id)
+            em.ok(f"default set — future `sndr up` will boot {preset_id}")
+        except ValueError:
+            pass
+
+
 # ── engine seams (each mocked in tests) — reuse the R1 run path ──────────────
 
 
@@ -395,7 +466,7 @@ def _docker_stop(name: str) -> bool:
     try:
         completed = subprocess.run(
             ["docker", "stop", name],
-            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=False,
         )
         return completed.returncode == 0
     except Exception:  # noqa: BLE001 — never raise out of a teardown
@@ -491,13 +562,13 @@ def _find_daemon_pids() -> list[int]:
     try:
         completed = subprocess.run(
             ["pgrep", "-f", "sndr.cli.legacy gui-api"],
-            capture_output=True, text=True,
+            capture_output=True, text=True, check=False,
         )
     except Exception:  # noqa: BLE001 — never raise out of a teardown
         return []
     pids: list[int] = []
-    for line in completed.stdout.splitlines():
-        line = line.strip()
+    for raw_line in completed.stdout.splitlines():
+        line = raw_line.strip()
         if line.isdigit():
             pids.append(int(line))
     return pids

--- a/sndr/cli/user_prefs.py
+++ b/sndr/cli/user_prefs.py
@@ -1,0 +1,210 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Per-user preference store — ``$SNDR_HOME/defaults.toml`` (never tracked).
+
+The zero-friction CLI needs to REMEMBER two things between invocations so the
+operator does not re-type them: their chosen default preset and the last remote
+rig they pointed a client at. This mirrors club-3090's DEFAULT-2 ``.env`` pin
+cache, adapted to OUR stack — a small stdlib-only TOML file under the existing
+``~/.sndr`` state directory (``SNDR_HOME``), so it is per-user and out of the
+repo by location.
+
+Two disciplines are baked in:
+
+  * **DEFAULT-2 slug validation** — :func:`set_default_preset` refuses a preset
+    that is not in ``registry_v2.list_presets()`` (a typo can never be pinned).
+  * **DEFAULT-4 precedence** — a value in the SHELL ENV
+    (``SNDR_DEFAULT_PRESET``) WINS over the file; :func:`resolve_default_preset`
+    surfaces which source won so a caller can tell the operator.
+
+Reads use stdlib ``tomllib``; writes use a tiny hand-rolled serializer (the
+values are preset slugs / URLs / DSNs — no nested structures), so this module
+adds no new dependency.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+import tomllib
+
+ENV_DEFAULT_PRESET = "SNDR_DEFAULT_PRESET"
+
+_SECTION_DEFAULTS = "defaults"
+_SECTION_REMOTE = "remote"
+_SECTION_MODELS = "models"
+
+
+# ── location ─────────────────────────────────────────────────────────────────
+
+
+def _sndr_home() -> Path:
+    """The state directory (``SNDR_HOME`` override, else ``~/.sndr``) — the same
+    convention :class:`sndr.config.SndrConfig` resolves."""
+    return Path(os.environ.get("SNDR_HOME") or (Path.home() / ".sndr")).expanduser()
+
+
+def _prefs_path() -> Path:
+    """Absolute path to the per-user prefs file (honors ``SNDR_HOME`` for tests)."""
+    return _sndr_home() / "defaults.toml"
+
+
+# ── raw read / write ─────────────────────────────────────────────────────────
+
+
+def _read() -> dict[str, Any]:
+    path = _prefs_path()
+    if not path.is_file():
+        return {}
+    try:
+        with path.open("rb") as handle:
+            return tomllib.load(handle)
+    except (OSError, tomllib.TOMLDecodeError):
+        # A corrupt/unreadable prefs file must never crash the CLI — treat it as
+        # empty (the caller falls through to auto-detected defaults).
+        return {}
+
+
+def _quote(value: str) -> str:
+    """Serialize a string as a TOML basic string (escape backslash + quote)."""
+    escaped = str(value).replace("\\", "\\\\").replace('"', '\\"')
+    return f'"{escaped}"'
+
+
+def _bare_key_ok(key: str) -> bool:
+    return bool(key) and all(c.isalnum() or c in "-_" for c in key)
+
+
+def _dumps(data: dict[str, dict[str, Any]]) -> str:
+    """Serialize the flat two-level ``{section: {key: value}}`` prefs mapping."""
+    lines: list[str] = []
+    for section, body in data.items():
+        if not isinstance(body, dict) or not body:
+            continue
+        lines.append(f"[{section}]")
+        for key, value in body.items():
+            if value is None:
+                continue
+            rendered_key = key if _bare_key_ok(key) else _quote(key)
+            lines.append(f"{rendered_key} = {_quote(str(value))}")
+        lines.append("")
+    return "\n".join(lines).rstrip("\n") + "\n"
+
+
+def _write(data: dict[str, dict[str, Any]]) -> None:
+    path = _prefs_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(_dumps(data), encoding="utf-8")
+
+
+# ── preset validation ────────────────────────────────────────────────────────
+
+
+def _known_presets() -> set[str]:
+    try:
+        from sndr.model_configs.registry_v2 import list_presets
+
+        return set(list_presets())
+    except Exception:  # noqa: BLE001 — registry import must never crash prefs I/O
+        return set()
+
+
+# ── default preset ───────────────────────────────────────────────────────────
+
+
+def resolve_default_preset(model_key: str | None = None) -> tuple[str | None, str]:
+    """Resolve the default preset AND the source that won.
+
+    Precedence (DEFAULT-4): shell env ``SNDR_DEFAULT_PRESET`` > per-model file
+    entry > global file entry > nothing. Returns ``(value_or_None, source)``
+    where ``source`` is one of ``env:SNDR_DEFAULT_PRESET`` / ``file:models`` /
+    ``file:defaults`` / ``unset``. The raw value is returned WITHOUT registry
+    validation so the caller can surface a stale pin; :func:`get_default_preset`
+    applies the validity filter.
+    """
+    env = os.environ.get(ENV_DEFAULT_PRESET, "").strip()
+    if env:
+        return env, f"env:{ENV_DEFAULT_PRESET}"
+
+    data = _read()
+    if model_key:
+        models = data.get(_SECTION_MODELS, {})
+        if isinstance(models, dict) and models.get(model_key):
+            return str(models[model_key]), "file:models"
+
+    defaults = data.get(_SECTION_DEFAULTS, {})
+    if isinstance(defaults, dict) and defaults.get("preset"):
+        return str(defaults["preset"]), "file:defaults"
+    return None, "unset"
+
+
+def get_default_preset(model_key: str | None = None) -> str | None:
+    """The default preset if one is set AND still a known preset, else None."""
+    value, _ = resolve_default_preset(model_key)
+    if value and value in _known_presets():
+        return value
+    return None
+
+
+def set_default_preset(preset_id: str) -> None:
+    """Pin ``preset_id`` as the operator's default. Validates against the
+    registry first (DEFAULT-2 slug validation)."""
+    if preset_id not in _known_presets():
+        raise ValueError("not a known preset — run `sndr preset list`")
+    data = _read()
+    defaults = data.get(_SECTION_DEFAULTS)
+    if not isinstance(defaults, dict):
+        defaults = {}
+    defaults["preset"] = preset_id
+    data[_SECTION_DEFAULTS] = defaults
+    _write(data)
+
+
+def clear_default_preset() -> None:
+    """Remove the pinned default preset (no-op when none is set)."""
+    data = _read()
+    defaults = data.get(_SECTION_DEFAULTS)
+    if isinstance(defaults, dict) and "preset" in defaults:
+        del defaults["preset"]
+        data[_SECTION_DEFAULTS] = defaults
+        _write(data)
+
+
+# ── last-used remote ─────────────────────────────────────────────────────────
+
+
+def get_last_remote() -> dict[str, Any] | None:
+    """The last remote the operator configured (``{url, key, dsn}``) or None."""
+    data = _read()
+    remote = data.get(_SECTION_REMOTE)
+    if isinstance(remote, dict) and remote.get("url"):
+        return {
+            "url": str(remote.get("url")),
+            "key": (str(remote["key"]) if remote.get("key") else None),
+            "dsn": (str(remote["dsn"]) if remote.get("dsn") else None),
+        }
+    return None
+
+
+def set_last_remote(url: str, key: str | None = None, dsn: str | None = None) -> None:
+    """Cache the last-used remote URL/key/DSN (DEFAULT-4 caching)."""
+    data = _read()
+    remote: dict[str, Any] = {"url": url}
+    if key:
+        remote["key"] = key
+    if dsn:
+        remote["dsn"] = dsn
+    data[_SECTION_REMOTE] = remote
+    _write(data)
+
+
+__all__ = [
+    "ENV_DEFAULT_PRESET",
+    "clear_default_preset",
+    "get_default_preset",
+    "get_last_remote",
+    "resolve_default_preset",
+    "set_default_preset",
+    "set_last_remote",
+    "_prefs_path",
+]

--- a/sndr/cli/user_prefs.py
+++ b/sndr/cli/user_prefs.py
@@ -16,9 +16,12 @@ Two disciplines are baked in:
     (``SNDR_DEFAULT_PRESET``) WINS over the file; :func:`resolve_default_preset`
     surfaces which source won so a caller can tell the operator.
 
-Reads use stdlib ``tomllib``; writes use a tiny hand-rolled serializer (the
-values are preset slugs / URLs / DSNs — no nested structures), so this module
-adds no new dependency.
+Reads prefer stdlib ``tomllib`` (Python 3.11+), fall back to ``tomli`` if it
+happens to be installed, and otherwise use a tiny built-in reader that
+understands exactly the flat ``[section] key = "value"`` subset :func:`_dumps`
+emits (Python 3.10 has no ``tomllib``, and the project supports ``>=3.10``).
+Writes use a tiny hand-rolled serializer (the values are preset slugs / URLs /
+DSNs — no nested structures), so this module adds no new dependency.
 """
 from __future__ import annotations
 
@@ -26,7 +29,13 @@ import os
 from pathlib import Path
 from typing import Any
 
-import tomllib
+try:  # Python 3.11+ ships tomllib in the stdlib.
+    import tomllib
+except ModuleNotFoundError:  # Python 3.10 — try the tomli backport if present.
+    try:
+        import tomli as tomllib  # type: ignore[no-redef]
+    except ModuleNotFoundError:  # neither available → built-in flat reader below.
+        tomllib = None  # type: ignore[assignment]
 
 ENV_DEFAULT_PRESET = "SNDR_DEFAULT_PRESET"
 
@@ -56,13 +65,57 @@ def _read() -> dict[str, Any]:
     path = _prefs_path()
     if not path.is_file():
         return {}
+    # A corrupt/unreadable prefs file must never crash the CLI — treat it as
+    # empty (the caller falls through to auto-detected defaults).
+    # ``tomllib.TOMLDecodeError`` subclasses ``ValueError`` in both stdlib and
+    # the tomli backport, so ``(OSError, ValueError)`` covers every reader path
+    # without referencing the class when ``tomllib`` is None on bare 3.10.
     try:
-        with path.open("rb") as handle:
-            return tomllib.load(handle)
-    except (OSError, tomllib.TOMLDecodeError):
-        # A corrupt/unreadable prefs file must never crash the CLI — treat it as
-        # empty (the caller falls through to auto-detected defaults).
+        if tomllib is not None:
+            with path.open("rb") as handle:
+                return tomllib.load(handle)
+        return _parse_flat_toml(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
         return {}
+
+
+def _unquote(token: str) -> str:
+    """Reverse :func:`_quote` for a TOML basic string; pass bare tokens through."""
+    if len(token) < 2 or token[0] != '"' or token[-1] != '"':
+        return token
+    inner = token[1:-1]
+    out: list[str] = []
+    i = 0
+    while i < len(inner):
+        ch = inner[i]
+        if ch == "\\" and i + 1 < len(inner) and inner[i + 1] in ('"', "\\"):
+            out.append(inner[i + 1])
+            i += 2
+            continue
+        out.append(ch)
+        i += 1
+    return "".join(out)
+
+
+def _parse_flat_toml(text: str) -> dict[str, Any]:
+    """Built-in reader for the flat ``[section] key = "value"`` files this module
+    writes — the Python 3.10 fallback when neither ``tomllib`` nor ``tomli`` is
+    installed. Only the subset :func:`_dumps` emits is understood; anything else
+    is ignored so a hand-edited file degrades to empty rather than crashing."""
+    result: dict[str, dict[str, Any]] = {}
+    section: dict[str, Any] | None = None
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("[") and line.endswith("]"):
+            section = result.setdefault(line[1:-1].strip(), {})
+            continue
+        if section is None or "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        section[_unquote(key.strip())] = _unquote(value.strip())
+    return result
 
 
 def _quote(value: str) -> str:

--- a/sndr/model_configs/host.py
+++ b/sndr/model_configs/host.py
@@ -40,7 +40,6 @@ import os
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Optional
 
 from sndr.model_configs.schema import SchemaError
 
@@ -50,7 +49,7 @@ class HostConfig:
     """Per-host resolved paths for symbolic mount references."""
     paths: dict[str, str] = field(default_factory=dict)
 
-    def get(self, name: str) -> Optional[str]:
+    def get(self, name: str) -> str | None:
         return self.paths.get(name)
 
 
@@ -167,7 +166,7 @@ _ENV_OVERRIDES: dict[str, tuple[str, ...]] = {
 }
 
 
-def _env_lookup(var: str) -> Optional[str]:
+def _env_lookup(var: str) -> str | None:
     """Return an absolute, existing-directory env override for `var`,
     or None when no recognised env is set or the value points at a
     non-existent path.
@@ -186,14 +185,14 @@ def _env_lookup(var: str) -> Optional[str]:
     return None
 
 
-def detect_paths(
-    models_candidates: Optional[list[str]] = None,
-    hf_cache_candidates: Optional[list[str]] = None,
-    triton_cache_candidates: Optional[list[str]] = None,
-    compile_cache_candidates: Optional[list[str]] = None,
-    sndr_src_candidates: Optional[list[str]] = None,
-    plugin_src_candidates: Optional[list[str]] = None,
-    cache_root_candidates: Optional[list[str]] = None,
+def detect_paths(  # noqa: PLR0912, PLR0915 — flat per-variable probe ladder; the branch/statement count mirrors the recognized-variable set and its precedence (env → candidates → optional-create) is frozen (host_autoinit contract) — splitting it would obscure that 1:1 mapping.
+    models_candidates: list[str] | None = None,
+    hf_cache_candidates: list[str] | None = None,
+    triton_cache_candidates: list[str] | None = None,
+    compile_cache_candidates: list[str] | None = None,
+    sndr_src_candidates: list[str] | None = None,
+    plugin_src_candidates: list[str] | None = None,
+    cache_root_candidates: list[str] | None = None,
     create_missing_caches: bool = False,
 ) -> dict[str, str]:
     """Auto-detect per-host paths by probing common locations.
@@ -348,17 +347,27 @@ def _default_host_yaml_path() -> Path:
     return sndr_default
 
 
-def load_host_config(path: Optional[Path] = None) -> HostConfig:
+def load_host_config(path: Path | None = None) -> HostConfig:
     """Load host config from YAML. Returns empty HostConfig if file absent."""
     p = path if path is not None else _default_host_yaml_path()
     if not p.is_file():
-        return HostConfig()
+        # BREAK #2 (2026-07-06): first-run auto-init. Only for the DEFAULT
+        # resolution (path is None — the real operator launch flow); explicit-
+        # path callers (tests/audits) keep the legacy "empty on absent"
+        # contract untouched. ensure_host_yaml is idempotent, non-TTY safe,
+        # and no-ops on a bare host, so nothing is written unless a real path
+        # is detectable. Opt out with SNDR_HOST_AUTOINIT=0.
+        if path is None and os.environ.get("SNDR_HOST_AUTOINIT", "1") != "0":
+            from sndr.model_configs.host_autoinit import ensure_host_yaml
+            ensure_host_yaml(path=p)
+        if not p.is_file():
+            return HostConfig()
     try:
         import yaml
     except ImportError:
         raise SchemaError(
             "host.py requires PyYAML to load host.yaml. Install pyyaml."
-        )
+        ) from None
     data = yaml.safe_load(p.read_text()) or {}
     if not isinstance(data, dict):
         raise SchemaError(
@@ -407,7 +416,7 @@ def _normalize_legacy_keys(paths: dict[str, str]) -> dict[str, str]:
     return paths
 
 
-def save_host_config(hc: HostConfig, path: Optional[Path] = None) -> Path:
+def save_host_config(hc: HostConfig, path: Path | None = None) -> Path:
     """Write host config as YAML. Creates parent dir if needed."""
     p = path if path is not None else _default_host_yaml_path()
     p.parent.mkdir(parents=True, exist_ok=True)
@@ -428,7 +437,7 @@ def save_host_config(hc: HostConfig, path: Optional[Path] = None) -> Path:
 
 
 def detect_and_save(
-    path: Optional[Path] = None,
+    path: Path | None = None,
     create_missing_caches: bool = False,
 ) -> tuple[HostConfig, Path]:
     """Detect paths + save to host.yaml. Convenience for install/first-run."""

--- a/sndr/model_configs/host_autoinit.py
+++ b/sndr/model_configs/host_autoinit.py
@@ -1,0 +1,76 @@
+# SPDX-License-Identifier: Apache-2.0
+"""First-run auto-init of `host.yaml` (BREAK #2 fix, 2026-07-06).
+
+A brand-new operator who never edited `~/.sndr/host.yaml` used to watch the
+launch renderer emit a literal ``${models_dir}`` token (or fatal with
+"unresolved ${models_dir}") because no per-host path map existed yet. This
+module closes that gap without changing any existing precedence:
+
+  ``ensure_host_yaml()`` — if the host.yaml is ABSENT, auto-detect the
+  conventional paths via the already-written ``host.detect_paths()`` and
+  persist them; if it is PRESENT, no-op. Env overrides (``SNDR_*`` /
+  ``GENESIS_*``) still pre-empt at detection time (they flow through
+  ``detect_paths``), so the DOWNLOAD-3 ladder (env > written file > probe)
+  is preserved: an env override is baked into the written map.
+
+Design contract:
+  * ADDITIVE — never removes or edits an existing host.yaml.
+  * IDEMPOTENT + resumable — safe to call on every launch; a second call on
+    an existing file is a no-op.
+  * NON-TTY safe — never prompts; writes the silently auto-detected map. On a
+    host where nothing is detectable it writes NOTHING (returns ``None``) so
+    read-only / CI callers on a bare runner are not polluted with an empty
+    stub file.
+  * NO baked operator paths — every candidate comes from
+    ``host.detect_paths()``; this module hardcodes none.
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from sndr.model_configs import host as _host
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def ensure_host_yaml(
+    persist: bool = True,
+    path: Path | None = None,
+) -> Path | None:
+    """Ensure a per-host ``host.yaml`` exists; auto-detect + write on first miss.
+
+    Args:
+        persist: when False, detect but do not write (dry-run probe). The
+            return value still reflects whether a write WOULD occur.
+        path: explicit host.yaml location; defaults to the canonical
+            resolution (``$SNDR_HOME``/``~/.sndr`` ladder) via host.py.
+
+    Returns:
+        * ``Path`` of the host.yaml that now exists (or would be written when
+          ``persist=False``), OR
+        * ``None`` when the file already exists (no-op) or nothing was
+          detectable (nothing written).
+    """
+    target = path if path is not None else _host._default_host_yaml_path()
+
+    # Present already -> idempotent no-op. Never touch an existing file.
+    if target.is_file():
+        return None
+
+    # Auto-detect the conventional paths. Env overrides pre-empt inside
+    # detect_paths(), so a set SNDR_MODELS_DIR / GENESIS_* wins here and is
+    # what gets written (env-wins ladder, at write time).
+    detected = _host.detect_paths()
+    if not detected:
+        # Bare host / CI runner with nothing to detect: writing an empty
+        # `paths: {}` file would provide no value and would pollute
+        # read-only callers. Leave the host absent; the resolve layer keeps
+        # its existing "unresolved -> fix host.yaml" behavior.
+        return None
+
+    if not persist:
+        return target
+
+    hc = _host.HostConfig(paths=detected)
+    return _host.save_host_config(hc, target)

--- a/tests/installer/test_client_profile.py
+++ b/tests/installer/test_client_profile.py
@@ -1,0 +1,177 @@
+# SPDX-License-Identifier: Apache-2.0
+"""GROUP-CONFIG (2026-07-06) — install.sh CLIENT PROFILE + zero-config seams.
+
+Bash-harness tests that RUN the real `install.sh` (in `--dry-run`, so no live
+clone / pip / launch) and assert on stdout + emitted files:
+
+  * a host with no `nvidia-smi` takes the CLIENT branch — CLI + GUI only, NO
+    engine/plugin install — and emits a prefilled Section-B `.env`;
+  * a faked-GPU host takes the LOCAL FULL-STACK branch — auto-copies a
+    Section-A `.env` from `.env.example` and runs the host.yaml auto-init;
+  * both are idempotent on re-run (DOWNLOAD-2) and dry-run safe (no `.git`).
+
+The controlled PATH (only the real python3/git/curl symlinked in, plus an
+optional fake nvidia-smi) makes GPU presence deterministic on any host — the
+rig has a real nvidia-smi, a laptop does not; the harness decides.
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+INSTALL_SH = REPO_ROOT / "install.sh"
+ENV_EXAMPLE = REPO_ROOT / ".env.example"
+
+
+def _make_toolbin(tmp_path: Path, *, with_gpu: bool) -> Path:
+    """Build a shim dir PREPENDED to the real PATH. It carries only an
+    `nvidia-smi` shim so GPU presence is deterministic on any host (the rig
+    has a real nvidia-smi; the shim always wins because it is first on PATH):
+      * with_gpu=True  -> reports 2× RTX A5000
+      * with_gpu=False -> reports NO GPUs (empty), so N_GPUS=0 -> client
+    All other tools (cut/sed/git/python3/...) resolve via the inherited PATH.
+    """
+    bindir = tmp_path / "bin"
+    bindir.mkdir(exist_ok=True)
+    smi = bindir / "nvidia-smi"
+    if with_gpu:
+        smi.write_text('#!/bin/bash\nprintf "NVIDIA RTX A5000\\nNVIDIA RTX A5000\\n"\n')
+    else:
+        # Present but reports zero GPUs -> N_GPUS=0 -> client profile.
+        smi.write_text('#!/bin/bash\nexit 0\n')
+    smi.chmod(0o755)
+    return bindir
+
+
+def _run_installer(tmp_path: Path, args: list[str], *, with_gpu: bool,
+                   extra_env: dict | None = None) -> subprocess.CompletedProcess:
+    bindir = _make_toolbin(tmp_path, with_gpu=with_gpu)
+    home = tmp_path / "home"
+    home.mkdir(exist_ok=True)
+    genesis_home = tmp_path / "genesis_home"
+    genesis_home.mkdir(exist_ok=True)
+    workdir = tmp_path / "work"
+    workdir.mkdir(exist_ok=True)
+    env = dict(os.environ)
+    env.pop("SNDR_HOST_AUTOINIT", None)
+    env.update({
+        "PATH": f"{bindir}{os.pathsep}{os.environ.get('PATH', '')}",
+        "HOME": str(home),
+        "SNDR_HOME": str(genesis_home),
+        "GENESIS_HOME": str(genesis_home),
+    })
+    if extra_env:
+        env.update({k: str(v) for k, v in extra_env.items()})
+    return subprocess.run(
+        ["bash", str(INSTALL_SH), "--dry-run", "-y", *args],
+        cwd=str(workdir),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=90,
+        check=False,
+    )
+
+
+# ─── Client profile (no GPU) ───────────────────────────────────────────────
+
+
+def test_no_gpu_takes_client_branch(tmp_path):
+    """No nvidia-smi -> CLIENT branch: CLI+GUI only, Section-B .env emitted,
+    NO engine/plugin install attempted, points at docs/RUN_ON_MAC.md."""
+    r = _run_installer(tmp_path, [], with_gpu=False)
+    assert r.returncode == 0, r.stdout + r.stderr
+    out = r.stdout
+    assert "client profile auto-selected" in out
+    assert "engine cannot run here" in out
+    assert "docs/RUN_ON_MAC.md" in out
+    # Engine/plugin bits must NOT run.
+    assert "Editable install" not in out
+    assert "Generate launch script" not in out
+    assert "generate_launch" not in out
+    assert "clone/pip not run" in out
+
+    env_file = (tmp_path / "work" / ".env")
+    assert env_file.is_file(), "client profile must emit a .env"
+    body = env_file.read_text()
+    assert "SNDR_OPENAI_BASE_URL=" in body
+    assert "SNDR_ENGINE_API_KEY=genesis-local" in body
+    assert "GENESIS_MEMORY_DSN=" in body
+
+
+def test_explicit_client_flag(tmp_path):
+    """--client forces the client branch even where a GPU exists."""
+    r = _run_installer(tmp_path, ["--client"], with_gpu=True)
+    assert r.returncode == 0, r.stdout + r.stderr
+    assert "client profile (forced" in r.stdout
+    assert (tmp_path / "work" / ".env").is_file()
+
+
+def test_client_env_honors_rig_env(tmp_path):
+    """A preset SNDR_OPENAI_BASE_URL is baked into the emitted .env."""
+    r = _run_installer(
+        tmp_path, ["--client"], with_gpu=False,
+        extra_env={"SNDR_OPENAI_BASE_URL": "http://rig.local:8102/v1"},
+    )
+    assert r.returncode == 0, r.stdout + r.stderr
+    body = (tmp_path / "work" / ".env").read_text()
+    assert "SNDR_OPENAI_BASE_URL=http://rig.local:8102/v1" in body
+
+
+def test_client_idempotent_rerun(tmp_path):
+    """Re-running the client install leaves an existing .env untouched."""
+    r1 = _run_installer(tmp_path, ["--client"], with_gpu=False)
+    assert r1.returncode == 0
+    env_file = tmp_path / "work" / ".env"
+    original = env_file.read_text()
+    # Second run: same tmp tree (so .env already exists in workdir).
+    r2 = _run_installer(tmp_path, ["--client"], with_gpu=False)
+    assert r2.returncode == 0
+    assert "left untouched" in r2.stdout
+    assert env_file.read_text() == original
+
+
+# ─── Local full stack (faked GPU) ──────────────────────────────────────────
+
+
+def test_faked_gpu_takes_full_stack_and_autocopies_env(tmp_path):
+    """A GPU host takes the full-stack branch: auto-copy Section-A .env from
+    .env.example + run host.yaml auto-init. Dry-run => no clone/pip."""
+    genesis_home = tmp_path / "genesis_home"
+    genesis_home.mkdir(exist_ok=True)
+    shutil.copy(ENV_EXAMPLE, genesis_home / ".env.example")
+
+    models = tmp_path / "models"
+    models.mkdir()
+    r = _run_installer(
+        tmp_path, [], with_gpu=True,
+        extra_env={"SNDR_MODELS_DIR": str(models)},
+    )
+    assert r.returncode == 0, r.stdout + r.stderr
+    out = r.stdout
+    assert "local full-stack profile" in out
+    assert "engine cannot run here" not in out
+    assert "Host paths auto-init" in out
+    assert "seams exercised" in out
+
+    env_file = genesis_home / ".env"
+    assert env_file.is_file(), "full-stack path must auto-copy .env from example"
+    # It is the Section-A scaffold (has the SECTION A banner), not Section-B.
+    assert "SECTION A" in env_file.read_text()
+
+
+def test_dry_run_is_safe_no_clone(tmp_path):
+    """Dry-run performs no live clone: GENESIS_HOME has no .git."""
+    r = _run_installer(tmp_path, [], with_gpu=False)
+    assert r.returncode == 0
+    assert not (tmp_path / "genesis_home" / ".git").exists()
+
+
+def test_installer_script_syntax_valid():
+    """`bash -n install.sh` — the script parses (guards the whole file)."""
+    r = subprocess.run(["bash", "-n", str(INSTALL_SH)],
+                       capture_output=True, text=True, check=False)
+    assert r.returncode == 0, r.stderr

--- a/tests/unit/cli/test_chat_remote_env.py
+++ b/tests/unit/cli/test_chat_remote_env.py
@@ -1,0 +1,87 @@
+# SPDX-License-Identifier: Apache-2.0
+"""UX GROUP-CLI (GAP 2) — ``sndr chat`` honors the remote-engine env.
+
+When a Mac/Windows client is pointed at a remote rig via
+``SNDR_OPENAI_BASE_URL`` (+ ``SNDR_ENGINE_API_KEY``), a bare ``sndr chat`` must
+probe THAT engine — parsing host/port from the base URL and passing the key —
+instead of the localhost:8000 default. Explicit ``--host`` / ``--port`` /
+preset STILL win; the local default path is unchanged when no remote env is set.
+"""
+from __future__ import annotations
+
+import argparse
+import io
+from contextlib import redirect_stderr, redirect_stdout
+
+import pytest
+
+pytest.importorskip("pydantic")
+
+from sndr.cli.commands.chat import ChatCommand  # noqa: E402
+
+
+def _ns(**kw):
+    base = {"preset": None, "port": None, "host": "127.0.0.1", "api_key": None, "output": "text"}
+    base.update(kw)
+    return argparse.Namespace(**base)
+
+
+def _patch_status(monkeypatch):
+    """Capture the engine_status call kwargs; report unreachable so the command
+    returns before opening a REPL."""
+    calls: list = []
+
+    def fake_status(host=None, *, port=None, timeout=3.0, api_key=None):
+        calls.append({"host": host, "port": port, "api_key": api_key})
+        return {"reachable": False, "error": "stub"}
+
+    from sndr.product_api.legacy import engine_client
+
+    monkeypatch.setattr(engine_client, "engine_status", fake_status)
+    return calls
+
+
+def _run(ns):
+    with redirect_stdout(io.StringIO()), redirect_stderr(io.StringIO()):
+        return ChatCommand().execute(ns)
+
+
+def test_remote_env_probes_remote_host_with_key(monkeypatch):
+    calls = _patch_status(monkeypatch)
+    monkeypatch.setenv("SNDR_OPENAI_BASE_URL", "http://192.168.1.10:8102/v1")
+    monkeypatch.setenv("SNDR_ENGINE_API_KEY", "genesis-local")
+
+    _run(_ns())
+    assert calls, "engine_status must be probed"
+    assert calls[0]["host"] == "192.168.1.10"
+    assert calls[0]["port"] == 8102
+    assert calls[0]["api_key"] == "genesis-local"
+
+
+def test_explicit_host_still_overrides_remote_env(monkeypatch):
+    calls = _patch_status(monkeypatch)
+    monkeypatch.setenv("SNDR_OPENAI_BASE_URL", "http://192.168.1.10:8102/v1")
+    monkeypatch.setenv("SNDR_ENGINE_API_KEY", "genesis-local")
+
+    _run(_ns(host="10.0.0.5", port=9001))
+    assert calls[0]["host"] == "10.0.0.5"
+    assert calls[0]["port"] == 9001
+
+
+def test_api_key_flag_threads_through(monkeypatch):
+    calls = _patch_status(monkeypatch)
+    monkeypatch.setenv("SNDR_OPENAI_BASE_URL", "http://192.168.1.10:8102/v1")
+    monkeypatch.delenv("SNDR_ENGINE_API_KEY", raising=False)
+
+    _run(_ns(api_key="flag-key"))
+    assert calls[0]["api_key"] == "flag-key"
+
+
+def test_local_default_path_unchanged_without_remote(monkeypatch):
+    calls = _patch_status(monkeypatch)
+    monkeypatch.delenv("SNDR_OPENAI_BASE_URL", raising=False)
+    monkeypatch.delenv("SNDR_ENGINE_API_KEY", raising=False)
+
+    _run(_ns())
+    assert calls[0]["host"] == "127.0.0.1"
+    assert calls[0]["port"] == 8000

--- a/tests/unit/cli/test_quickstart.py
+++ b/tests/unit/cli/test_quickstart.py
@@ -1,0 +1,181 @@
+# SPDX-License-Identifier: Apache-2.0
+"""UX GROUP-CLI — ``sndr quickstart`` (the zero-decision front door).
+
+``quickstart`` detects the rig + OS, resolves a fitting preset via the
+progressive ladder (explicit > pinned default > top-fit), prints the per-card
+VRAM projection with a hard FAIL gate, and delegates the actual bring-up to the
+EXISTING ``sndr up`` seams — it never reimplements an engine or a server.
+
+Every side-effectful step is mocked; these tests assert only wiring + policy:
+
+  * registration on the canonical surface;
+  * ``--fake-gpus … --no-input --dry-run`` resolves a fitting preset and never
+    reads stdin (PICKER-2 non-interactive escape);
+  * a non-fitting rig -> FAIL projection -> exit 2 unless ``--force`` (VRAM-1);
+  * empty rig + ``SNDR_OPENAI_BASE_URL`` -> pivots to no-engine client mode
+    (GAP 3), with NO engine launch;
+  * empty rig + NO remote -> exit 2 with the actionable remote-setup hint
+    (never a bare "no preset fits");
+  * a pinned default is chosen over the top-fit, and the post-boot "make
+    default?" offer only fires when not ``--no-input`` (DEFAULT-1).
+"""
+from __future__ import annotations
+
+import argparse
+import io
+from contextlib import redirect_stderr, redirect_stdout
+
+import pytest
+
+pytest.importorskip("pydantic")
+
+import sndr.cli.commands.quickstart as qs  # noqa: E402
+from sndr.cli.commands.quickstart import QuickstartCommand  # noqa: E402
+from sndr.model_configs.preflight_fit import DetectedGpu, Rig  # noqa: E402
+
+TWO_A5000 = "RTX A5000:24564:8.6;RTX A5000:24564:8.6"
+
+
+def _ns(**kw):
+    base = {
+        "preset": None,
+        "no_input": False,
+        "force": False,
+        "gui_port": 8765,
+        "dry_run": False,
+        "rig": None,
+        "fake_gpus": None,
+        "output": "text",
+    }
+    base.update(kw)
+    return argparse.Namespace(**base)
+
+
+def _empty_rig() -> Rig:
+    return Rig(gpus=[], source="nvidia-smi")
+
+
+def _a5000_rig() -> Rig:
+    g = [DetectedGpu(index=i, name="RTX A5000", vram_mib=24564, compute_cap=(8, 6)) for i in range(2)]
+    return Rig(gpus=g, source="fake")
+
+
+def _run(cmd, ns):
+    out, err = io.StringIO(), io.StringIO()
+    with redirect_stdout(out), redirect_stderr(err):
+        rc = cmd.execute(ns)
+    return rc, out.getvalue() + err.getvalue()
+
+
+# ── 1. registration ──────────────────────────────────────────────────────────
+
+
+def test_quickstart_registered():
+    from sndr.cli.commands import COMMAND_REGISTRY
+    from sndr.cli.main import build_parser
+
+    build_parser()
+    assert "quickstart" in COMMAND_REGISTRY
+
+
+# ── 2. non-interactive dry-run resolves a fitting preset, never reads stdin ───
+
+
+def test_dry_run_no_input_resolves_and_never_reads_stdin(monkeypatch):
+    def _boom(*a, **k):  # any stdin read is a bug in the non-interactive path
+        raise AssertionError("quickstart read stdin in --no-input mode")
+
+    monkeypatch.setattr("builtins.input", _boom)
+    booted: list = []
+    monkeypatch.setattr(qs, "_boot", lambda ns: booted.append(ns) or 0)
+
+    rc, text = _run(QuickstartCommand(), _ns(fake_gpus=TWO_A5000, no_input=True, dry_run=True))
+    assert rc == 0
+    assert booted == []  # dry-run starts nothing
+    # A concrete fitting preset name is surfaced.
+    assert "prod-qwen3.6-35b" in text
+
+
+# ── 3. non-fitting rig -> FAIL projection -> exit 2 unless --force ────────────
+
+
+def test_non_fitting_rig_fails_projection(monkeypatch):
+    tiny = Rig(gpus=[DetectedGpu(index=0, name="TinyGPU", vram_mib=2048, compute_cap=(8, 6))], source="fake")
+    monkeypatch.setattr(qs, "_detect_rig", lambda args: tiny)
+    monkeypatch.setattr(qs, "_boot", lambda ns: 0)
+
+    # Explicit heavy preset on a 2 GiB card -> byte-level projection FAILs.
+    rc, text = _run(QuickstartCommand(), _ns(preset="prod-qwen3.6-35b-balanced", no_input=True))
+    assert rc == 2
+    assert "force" in text.lower()
+
+
+def test_non_fitting_rig_force_overrides(monkeypatch):
+    tiny = Rig(gpus=[DetectedGpu(index=0, name="TinyGPU", vram_mib=2048, compute_cap=(8, 6))], source="fake")
+    monkeypatch.setattr(qs, "_detect_rig", lambda args: tiny)
+    booted: list = []
+    monkeypatch.setattr(qs, "_boot", lambda ns: booted.append(ns) or 0)
+
+    rc, _ = _run(QuickstartCommand(), _ns(preset="prod-qwen3.6-35b-balanced", no_input=True, force=True))
+    assert rc == 0
+    assert len(booted) == 1  # --force pushes past the FAIL gate
+
+
+# ── 4. remote pivot: empty rig + SNDR_OPENAI_BASE_URL -> client mode ──────────
+
+
+def test_empty_rig_with_remote_pivots_to_no_engine(monkeypatch):
+    monkeypatch.setattr(qs, "_detect_rig", lambda args: _empty_rig())
+    monkeypatch.setenv("SNDR_OPENAI_BASE_URL", "http://192.168.1.10:8102/v1")
+    booted: list = []
+    monkeypatch.setattr(qs, "_boot", lambda ns: booted.append(ns) or 0)
+
+    rc, text = _run(QuickstartCommand(), _ns(no_input=True))
+    assert rc == 0
+    assert len(booted) == 1
+    assert booted[0].no_engine is True  # daemon-only, no engine launch
+    assert "192.168.1.10:8102" in text
+
+
+def test_empty_rig_no_remote_gives_setup_hint(monkeypatch):
+    monkeypatch.setattr(qs, "_detect_rig", lambda args: _empty_rig())
+    monkeypatch.delenv("SNDR_OPENAI_BASE_URL", raising=False)
+    booted: list = []
+    monkeypatch.setattr(qs, "_boot", lambda ns: booted.append(ns) or 0)
+
+    rc, text = _run(QuickstartCommand(), _ns(no_input=True))
+    assert rc == 2
+    assert booted == []
+    assert "remote setup" in text.lower()
+    assert "no preset fits" not in text.lower()  # not the bare error
+
+
+# ── 5. pinned default beats top-fit; post-boot offer gated by --no-input ──────
+
+
+def test_pinned_default_beats_top_fit(monkeypatch):
+    monkeypatch.setattr(qs, "_detect_rig", lambda args: _a5000_rig())
+    # Pin a fitting preset that is NOT the top-fit.
+    monkeypatch.setattr(qs.user_prefs, "get_default_preset", lambda model_key=None: "prod-qwen3.6-35b-balanced")
+    booted: list = []
+    monkeypatch.setattr(qs, "_boot", lambda ns: booted.append(ns) or 0)
+    offered: list = []
+    monkeypatch.setattr(qs, "_maybe_offer_set_default", lambda pid, **k: offered.append(pid))
+
+    rc, _ = _run(QuickstartCommand(), _ns(no_input=True))
+    assert rc == 0
+    assert booted[0].preset == "prod-qwen3.6-35b-balanced"
+    # --no-input suppresses the interactive "make default?" offer.
+    assert offered == []
+
+
+def test_post_boot_offer_fires_when_interactive(monkeypatch):
+    monkeypatch.setattr(qs, "_detect_rig", lambda args: _a5000_rig())
+    monkeypatch.setattr(qs.user_prefs, "get_default_preset", lambda model_key=None: None)
+    monkeypatch.setattr(qs, "_boot", lambda ns: 0)
+    offered: list = []
+    monkeypatch.setattr(qs, "_maybe_offer_set_default", lambda pid, **k: offered.append(pid))
+
+    rc, _ = _run(QuickstartCommand(), _ns(no_input=False))
+    assert rc == 0
+    assert len(offered) == 1  # interactive => the offer seam is invoked

--- a/tests/unit/cli/test_quickstart_lone_user_default.py
+++ b/tests/unit/cli/test_quickstart_lone_user_default.py
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Zero-decision default must be lone-user-SAFE, not peak-throughput.
+
+Fast-follow to the UX wizard: the fit ranking sorts by measured metric
+desc, so `-multiconc` presets (aggregate TPS, ~100% per-card VRAM at
+max_num_seqs=8) outrank the single-stream `balanced` preset. A newcomer
+running `sndr quickstart` with no flags gets no benefit from multiconc but
+takes its OOM risk — the auto-default must prefer the balanced/single-conc
+preset (matching what the README documents as the lone-user default).
+"""
+from __future__ import annotations
+
+from sndr.cli.commands.quickstart import _lone_user_first
+
+
+def test_non_multiconc_preset_ranks_first_for_the_auto_default():
+    fitting = [
+        "prod-qwen3.6-35b-multiconc",
+        "prod-qwen3.6-35b-balanced",
+    ]
+    assert _lone_user_first(fitting)[0] == "prod-qwen3.6-35b-balanced"
+
+
+def test_unchanged_when_top_is_not_multiconc():
+    fitting = ["prod-gemma4-26b-default", "prod-qwen3.6-27b-tq-k8v4"]
+    assert _lone_user_first(fitting) == fitting
+
+
+def test_cross_model_order_untouched_no_same_model_sibling():
+    # a-multiconc leads but has no same-model non-multiconc sibling -> stays
+    # (surgical: only swaps for its OWN sibling, never changes the model)
+    fitting = ["prod-a-multiconc", "prod-b-balanced"]
+    assert _lone_user_first(fitting) == fitting
+
+
+def test_multiconc_leader_swapped_for_same_model_sibling_only():
+    fitting = ["prod-qwen3.6-35b-multiconc", "prod-gemma4-31b-chat",
+               "prod-qwen3.6-35b-balanced"]
+    out = _lone_user_first(fitting)
+    assert out[0] == "prod-qwen3.6-35b-balanced"  # same-model sibling promoted
+    assert set(out) == set(fitting)  # nothing dropped
+    assert "prod-gemma4-31b-chat" in out  # cross-model entry preserved

--- a/tests/unit/cli/test_remote_setup.py
+++ b/tests/unit/cli/test_remote_setup.py
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: Apache-2.0
+"""UX GROUP-CLI (GAP 1) — ``sndr remote setup`` client onboarding.
+
+Configures THIS machine to drive a remote rig engine (Mac/Windows client mode).
+It validates the URL form (GUARD-1 loud typed refusal on a bad URL), probes
+reachability best-effort, persists the last-used remote, and prints the three
+canonical exports with a "shell env wins" note.
+"""
+from __future__ import annotations
+
+import argparse
+import io
+from contextlib import redirect_stderr, redirect_stdout
+
+import pytest
+
+pytest.importorskip("pydantic")
+
+import sndr.cli.commands.remote as remote_mod  # noqa: E402
+from sndr.cli import user_prefs  # noqa: E402
+from sndr.cli.commands.remote import RemoteSetupCommand  # noqa: E402
+
+
+def _ns(**kw):
+    base = {
+        "remote_cmd": "setup", "url": None, "key": "genesis-local",
+        "dsn": None, "write_env": False, "output": "text",
+    }
+    base.update(kw)
+    return argparse.Namespace(**base)
+
+
+@pytest.fixture(autouse=True)
+def _home(tmp_path, monkeypatch):
+    monkeypatch.setenv("SNDR_HOME", str(tmp_path))
+    # Keep the probe offline/deterministic.
+    monkeypatch.setattr(
+        remote_mod, "_probe_remote",
+        lambda host, port, key: {"reachable": False, "error": "offline in test"},
+    )
+    return tmp_path
+
+
+def _run(ns):
+    out = io.StringIO()
+    with redirect_stdout(out), redirect_stderr(out):
+        rc = RemoteSetupCommand().execute(ns)
+    return rc, out.getvalue()
+
+
+def test_setup_prints_three_exports_and_persists(monkeypatch):
+    rc, text = _run(_ns(url="http://192.168.1.10:8102/v1", key="genesis-local"))
+    assert rc == 0
+    assert "SNDR_OPENAI_BASE_URL" in text
+    assert "SNDR_ENGINE_API_KEY" in text
+    assert "GENESIS_MEMORY_DSN" in text
+    # persisted for next time
+    r = user_prefs.get_last_remote()
+    assert r is not None
+    assert r["url"] == "http://192.168.1.10:8102/v1"
+    assert r["key"] == "genesis-local"
+
+
+def test_bad_url_form_is_a_typed_refusal():
+    rc, text = _run(_ns(url="not-a-real-url"))
+    assert rc == 64  # EX_USAGE — loud typed refusal
+    assert "url" in text.lower()
+
+
+def test_write_env_writes_dotenv(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    rc, _ = _run(_ns(url="http://192.168.1.10:8102/v1", write_env=True))
+    assert rc == 0
+    env = (tmp_path / ".env").read_text(encoding="utf-8")
+    assert "SNDR_OPENAI_BASE_URL=http://192.168.1.10:8102/v1" in env

--- a/tests/unit/cli/test_up_remote_and_default.py
+++ b/tests/unit/cli/test_up_remote_and_default.py
@@ -1,0 +1,133 @@
+# SPDX-License-Identifier: Apache-2.0
+"""UX GROUP-CLI — additive ``sndr up`` branches (remote pivot + pinned default).
+
+These assert ONLY the new additive behavior; the existing ``up`` seams and
+return codes are exercised by ``test_up_open_down.py`` and stay untouched:
+
+  * empty rig + ``SNDR_OPENAI_BASE_URL`` -> auto no-engine daemon path (instead
+    of the return-2 "no preset fits"); no remote -> still return 2;
+  * a pinned default preset is consulted BEFORE the top-fit when no preset arg
+    is given;
+  * the post-boot ``_maybe_offer_set_default`` seam is guarded by ``--no-input``.
+"""
+from __future__ import annotations
+
+import argparse
+import io
+from contextlib import redirect_stderr, redirect_stdout
+
+import pytest
+
+pytest.importorskip("pydantic")
+
+import sndr.cli.commands.up as up_mod  # noqa: E402
+from sndr.cli.commands.up import UpCommand  # noqa: E402
+
+TWO_A5000 = "RTX A5000:24564:8.6;RTX A5000:24564:8.6"
+
+
+def _up_ns(**kw):
+    base = {
+        "preset": None, "rig": None, "fake_gpus": None, "port": None, "gui_port": 8765,
+        "dry_run": False, "no_input": False, "no_engine": False, "timeout": 300,
+        "output": "text",
+    }
+    base.update(kw)
+    return argparse.Namespace(**base)
+
+
+def _patch_pipeline(monkeypatch, *, events, engine_ok=True, daemon_ok=True):
+    def fake_ensure_weights(preset_id, *, dry_run=False):
+        events.append(("ensure_weights", preset_id))
+        return 0
+
+    def fake_launch_engine(preset_id, *, port=None, dry_run=False):
+        events.append(("launch_engine", preset_id, port))
+        return 0
+
+    def fake_wait_engine(host, port, *, timeout, on_progress=None):
+        events.append(("wait_engine", host, port))
+        return {"reachable": engine_ok, "models": ["m"], "error": None}
+
+    def fake_start_daemon(host, port):
+        events.append(("start_daemon", host, port))
+        return object()
+
+    def fake_wait_daemon(host, port, *, timeout):
+        events.append(("wait_daemon", host, port))
+        return daemon_ok
+
+    monkeypatch.setattr(up_mod, "_ensure_weights", fake_ensure_weights)
+    monkeypatch.setattr(up_mod, "_launch_engine_detached", fake_launch_engine)
+    monkeypatch.setattr(up_mod, "_wait_engine_ready", fake_wait_engine)
+    monkeypatch.setattr(up_mod, "_start_daemon", fake_start_daemon)
+    monkeypatch.setattr(up_mod, "_wait_daemon_ready", fake_wait_daemon)
+
+
+def _run(ns):
+    out = io.StringIO()
+    with redirect_stdout(out), redirect_stderr(out):
+        rc = UpCommand().execute(ns)
+    return rc, out.getvalue()
+
+
+# ── remote pivot ─────────────────────────────────────────────────────────────
+
+
+def test_empty_rig_with_remote_pivots_to_no_engine(monkeypatch):
+    events: list = []
+    _patch_pipeline(monkeypatch, events=events)
+    monkeypatch.setenv("SNDR_OPENAI_BASE_URL", "http://192.168.1.10:8102/v1")
+    # fake_gpus="" -> an empty rig -> nothing fits -> would normally return 2.
+    rc, _ = _run(_up_ns(fake_gpus="", no_input=True))
+    kinds = [e[0] for e in events]
+    assert rc == 0
+    assert "launch_engine" not in kinds  # no engine in client mode
+    assert "start_daemon" in kinds       # daemon still comes up
+
+
+def test_empty_rig_no_remote_still_returns_2(monkeypatch):
+    events: list = []
+    _patch_pipeline(monkeypatch, events=events)
+    monkeypatch.delenv("SNDR_OPENAI_BASE_URL", raising=False)
+    rc, _ = _run(_up_ns(fake_gpus="", no_input=True))
+    assert rc == 2
+    assert events == []
+
+
+# ── pinned default consulted before top-fit ──────────────────────────────────
+
+
+def test_pinned_default_consulted_before_top_fit(monkeypatch):
+    events: list = []
+    _patch_pipeline(monkeypatch, events=events)
+    monkeypatch.setattr(
+        up_mod.user_prefs, "get_default_preset",
+        lambda model_key=None: "prod-qwen3.6-35b-balanced",
+    )
+    rc, _ = _run(_up_ns(fake_gpus=TWO_A5000, no_input=True))
+    assert rc == 0
+    launched = [e for e in events if e[0] == "launch_engine"]
+    assert launched
+    assert launched[0][1] == "prod-qwen3.6-35b-balanced"
+
+
+# ── post-boot offer gated by --no-input ──────────────────────────────────────
+
+
+def test_offer_not_called_with_no_input(monkeypatch):
+    events: list = []
+    _patch_pipeline(monkeypatch, events=events)
+    offered: list = []
+    monkeypatch.setattr(up_mod, "_maybe_offer_set_default", offered.append)
+    _run(_up_ns(fake_gpus=TWO_A5000, no_input=True))
+    assert offered == []
+
+
+def test_offer_called_without_no_input(monkeypatch):
+    events: list = []
+    _patch_pipeline(monkeypatch, events=events)
+    offered: list = []
+    monkeypatch.setattr(up_mod, "_maybe_offer_set_default", offered.append)
+    _run(_up_ns(fake_gpus=TWO_A5000, no_input=False))
+    assert len(offered) == 1

--- a/tests/unit/cli/test_user_prefs.py
+++ b/tests/unit/cli/test_user_prefs.py
@@ -75,3 +75,23 @@ def test_last_remote_roundtrip(home_dir):
     assert r["url"] == "http://192.168.1.10:8102/v1"
     assert r["key"] == "genesis-local"
     assert "genesis_memory" in r["dsn"]
+
+
+def test_read_without_tomllib_uses_builtin_reader(home_dir, monkeypatch):
+    """Python 3.10 has no stdlib ``tomllib``; with no ``tomli`` backport either,
+    reads must fall back to the built-in flat parser and still round-trip what
+    ``_write`` emits. Regression guard for the 3.10 CI-collection break."""
+    # Write with the normal path, then read back as if tomllib/tomli were absent.
+    user_prefs.set_last_remote(
+        "http://<your-host>:8102/v1",
+        key="genesis-local",
+        dsn="postgresql://u:p@127.0.0.1:55432/genesis_memory",
+    )
+    user_prefs.set_default_preset(_a_real_preset())
+    monkeypatch.setattr(user_prefs, "tomllib", None)
+    r = user_prefs.get_last_remote()
+    assert r is not None
+    assert r["url"] == "http://<your-host>:8102/v1"
+    assert r["key"] == "genesis-local"
+    assert "genesis_memory" in r["dsn"]
+    assert user_prefs.get_default_preset() == _a_real_preset()

--- a/tests/unit/cli/test_user_prefs.py
+++ b/tests/unit/cli/test_user_prefs.py
@@ -1,0 +1,77 @@
+# SPDX-License-Identifier: Apache-2.0
+"""UX GROUP-CLI — per-user default/preference store (``sndr/cli/user_prefs.py``).
+
+The store mirrors club-3090's DEFAULT-2 ``.env`` pin cache, adapted to OUR
+stack: a per-user ``$SNDR_HOME/defaults.toml`` (never tracked in the repo) that
+remembers the operator's chosen default preset and last-used remote. Two
+disciplines are asserted here:
+
+  * DEFAULT-2 slug validation — ``set_default_preset`` refuses a preset that is
+    not in ``registry_v2.list_presets()`` (so a typo can never be persisted);
+  * DEFAULT-4 precedence — a value in the SHELL ENV (``SNDR_DEFAULT_PRESET``)
+    WINS over the file, and the resolver surfaces which source won.
+"""
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("pydantic")
+
+from sndr.cli import user_prefs  # noqa: E402
+from sndr.model_configs.registry_v2 import list_presets  # noqa: E402
+
+
+@pytest.fixture
+def home_dir(tmp_path, monkeypatch):
+    monkeypatch.setenv("SNDR_HOME", str(tmp_path))
+    monkeypatch.delenv("SNDR_DEFAULT_PRESET", raising=False)
+    return tmp_path
+
+
+def _a_real_preset() -> str:
+    return list_presets()[0]
+
+
+def test_prefs_path_honors_sndr_home(home_dir):
+    assert user_prefs._prefs_path() == home_dir / "defaults.toml"
+
+
+def test_default_preset_roundtrip(home_dir):
+    assert user_prefs.get_default_preset() is None
+    p = _a_real_preset()
+    user_prefs.set_default_preset(p)
+    assert user_prefs.get_default_preset() == p
+    user_prefs.clear_default_preset()
+    assert user_prefs.get_default_preset() is None
+
+
+def test_set_rejects_unknown_preset(home_dir):
+    with pytest.raises(ValueError, match="known preset"):
+        user_prefs.set_default_preset("definitely-not-a-real-preset")
+
+
+def test_shell_env_wins_over_file(home_dir, monkeypatch):
+    presets = list_presets()
+    file_preset, env_preset = presets[0], presets[1]
+    user_prefs.set_default_preset(file_preset)
+    monkeypatch.setenv("SNDR_DEFAULT_PRESET", env_preset)
+    # env wins
+    assert user_prefs.get_default_preset() == env_preset
+    # and the resolver names the source
+    value, source = user_prefs.resolve_default_preset()
+    assert value == env_preset
+    assert "env" in source.lower()
+
+
+def test_last_remote_roundtrip(home_dir):
+    assert user_prefs.get_last_remote() is None
+    user_prefs.set_last_remote(
+        "http://192.168.1.10:8102/v1",
+        key="genesis-local",
+        dsn="postgresql://u:p@127.0.0.1:55432/genesis_memory",
+    )
+    r = user_prefs.get_last_remote()
+    assert r is not None
+    assert r["url"] == "http://192.168.1.10:8102/v1"
+    assert r["key"] == "genesis-local"
+    assert "genesis_memory" in r["dsn"]

--- a/tests/unit/scripts/test_security_scan.py
+++ b/tests/unit/scripts/test_security_scan.py
@@ -22,13 +22,9 @@ from __future__ import annotations
 
 import importlib.util
 import json
-import re
 import subprocess
 import sys
 from pathlib import Path
-
-import pytest
-
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 SCRIPT_PATH = REPO_ROOT / "scripts" / "security_scan.py"
@@ -242,11 +238,22 @@ class TestEnvFiles:
         # ".envrc-example".startswith(".env.") = False. So it should pass.
         assert result == []
 
-    def test_env_example_flagged(self):
-        """`.env.example` IS flagged as a `.env.*` file."""
+    def test_env_example_allowed(self):
+        """`.env.example` is a secret-free TEMPLATE — it is meant to be
+        committed, so it must NOT be flagged (regression: the root
+        `.env.example` scaffold shipped 2026-07-06)."""
         mod = _import_script()
-        result = mod.check_no_env_files([".env.example"])
-        assert len(result) == 1
+        assert mod.check_no_env_files([".env.example"]) == []
+        # Other conventional template suffixes are waived too.
+        assert mod.check_no_env_files(["dir/.env.sample"]) == []
+        assert mod.check_no_env_files([".env.template"]) == []
+        assert mod.check_no_env_files([".env.dist"]) == []
+
+    def test_real_env_variants_still_flagged(self):
+        """Real, secret-bearing env files stay forbidden."""
+        mod = _import_script()
+        assert mod.check_no_env_files([".env.production"]) == [".env.production"]
+        assert mod.check_no_env_files(["svc/.env.staging"]) == ["svc/.env.staging"]
 
 
 # ─── AWS keys ──────────────────────────────────────────────────────────
@@ -301,6 +308,7 @@ class TestLive:
             capture_output=True,
             text=True,
             timeout=15,
+            check=False,
         )
         assert result.returncode == 0, (
             f"security_scan failed on live repo:\n{result.stdout}"
@@ -313,6 +321,7 @@ class TestLive:
             capture_output=True,
             text=True,
             timeout=15,
+            check=False,
         )
         assert result.returncode == 0
         payload = json.loads(result.stdout)

--- a/tests/unit/test_env_example.py
+++ b/tests/unit/test_env_example.py
@@ -1,0 +1,118 @@
+# SPDX-License-Identifier: Apache-2.0
+"""GROUP-CONFIG (2026-07-06) — the root `.env.example` scaffold contract.
+
+`.env.example` is the copy-and-edit-only-what-you-want scaffold (GAP 1). It
+must be a literal KEY=VALUE file (docker-compose semantics, NOT `source`d),
+document the Section-B remote triplet, carry Section-A defaults that MATCH the
+code's real defaults, be English-only, and carry no real secrets.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ENV_EXAMPLE = REPO_ROOT / ".env.example"
+
+# KEY=VALUE, tolerating a leading comment marker (the scaffold ships every
+# knob commented so a zero-edit copy still boots on auto-defaults).
+_KV_RE = re.compile(r"^#?\s*(?P<key>[A-Z][A-Z0-9_]*)=(?P<val>.*)$")
+
+
+def _parse_kv(text: str) -> dict[str, str]:
+    """Parse the scaffold line-by-line as KEY=VALUE (never `source`)."""
+    out: dict[str, str] = {}
+    for raw in text.splitlines():
+        line = raw.rstrip("\r")
+        m = _KV_RE.match(line)
+        if not m:
+            continue
+        out[m.group("key")] = m.group("val").strip()
+    return out
+
+
+def test_env_example_exists_at_repo_root():
+    assert ENV_EXAMPLE.is_file(), ".env.example must live at the repo root"
+
+
+def test_parses_as_key_value_not_source():
+    """Every documented knob is a plain KEY=VALUE line — no `$(...)`, no
+    `${OTHER}` interpolation, no `export ` prefix (it is read literally,
+    not sourced)."""
+    text = ENV_EXAMPLE.read_text(encoding="utf-8")
+    kv = _parse_kv(text)
+    assert kv, "no KEY=VALUE lines parsed from .env.example"
+    for line in text.splitlines():
+        stripped = line.lstrip("#").strip()
+        assert not stripped.startswith("export "), (
+            f"scaffold is read literally, not sourced: {line!r}"
+        )
+    # No command substitution / shell interpolation in actual VALUES (prose
+    # comments may mention `$(...)` when explaining that it is unsupported).
+    for key, val in kv.items():
+        assert "$(" not in val, f"no command substitution in value of {key}: {val!r}"
+        assert "${" not in val, f"no interpolation in value of {key}: {val!r}"
+
+
+def test_section_b_remote_triplet_present():
+    """The remote-client triplet (the only genuinely manual surface) must be
+    documented."""
+    kv = _parse_kv(ENV_EXAMPLE.read_text(encoding="utf-8"))
+    for key in ("SNDR_OPENAI_BASE_URL", "SNDR_ENGINE_API_KEY",
+                "GENESIS_MEMORY_DSN"):
+        assert key in kv, f"Section-B triplet key missing: {key}"
+
+
+def test_section_a_defaults_match_code():
+    """Section-A documented defaults must match the code's real defaults."""
+    text = ENV_EXAMPLE.read_text(encoding="utf-8")
+    kv = _parse_kv(text)
+    # SNDR_ENGINE_API_KEY default must match schema.py ModelConfig.api_key.
+    import dataclasses
+
+    from sndr.model_configs.schema import ModelConfig
+    schema_default = {
+        f.name: f.default for f in dataclasses.fields(ModelConfig)
+    }["api_key"]
+    assert schema_default == "genesis-local"
+    assert kv.get("SNDR_ENGINE_API_KEY") == schema_default
+    # GUI daemon port.
+    assert kv.get("SNDR_GUI_PORT") == "8765"
+    # Engine self-launch port 8000 must appear (documented default).
+    assert "8000" in text, "engine self-launch port 8000 must be documented"
+    # Default engine overlay.
+    assert kv.get("SNDR_ENGINE") == "vllm"
+
+
+def test_comments_are_english_only_ascii():
+    """Language rule: the scaffold's comments/strings are English only."""
+    text = ENV_EXAMPLE.read_text(encoding="utf-8")
+    for i, line in enumerate(text.splitlines(), 1):
+        # Box-drawing chars used for section rules are allowed; flag any
+        # non-ASCII LETTER (would signal a non-English word slipped in).
+        for ch in line:
+            if ch.isalpha() and ord(ch) > 127:
+                raise AssertionError(
+                    f".env.example L{i}: non-English/non-ASCII letter "
+                    f"{ch!r} in {line!r}"
+                )
+
+
+def test_no_real_secrets_committed():
+    """No AWS keys, no private-key blocks, no long opaque tokens. The dev
+    defaults genesis-local / genesis_mem_dev are established non-secrets."""
+    text = ENV_EXAMPLE.read_text(encoding="utf-8")
+    assert not re.search(r"\bAKIA[A-Z0-9]{16}\b", text), "AWS key leaked"
+    assert "PRIVATE KEY" not in text, "private-key block leaked"
+    # A crude opaque-token sniff: a 40+ char run of base64-ish chars that is
+    # not one of the whitelisted placeholders.
+    for tok in re.findall(r"[A-Za-z0-9+/_-]{40,}", text):
+        assert tok in ("YOUR_RIG_HOST",), f"suspicious long token: {tok!r}"
+
+
+def test_gitignore_tracks_the_template():
+    """`.env` is ignored but `.env.example` is explicitly tracked (negation)."""
+    gi = (REPO_ROOT / ".gitignore").read_text(encoding="utf-8")
+    assert "!.env.example" in gi, (
+        ".gitignore must negate .env.example so the scaffold is tracked"
+    )

--- a/tests/unit/test_host_autoinit.py
+++ b/tests/unit/test_host_autoinit.py
@@ -1,0 +1,139 @@
+# SPDX-License-Identifier: Apache-2.0
+"""GROUP-CONFIG (2026-07-06) — host.yaml first-run auto-init (BREAK #2).
+
+A brand-new operator with no `host.yaml` must never watch the launch renderer
+emit a literal `${models_dir}`. `ensure_host_yaml()` auto-detects + persists on
+first miss, is idempotent on a present file, and preserves the env-wins ladder
+(DOWNLOAD-3): a `GENESIS_*` / `SNDR_*` override is baked into the written map.
+"""
+from __future__ import annotations
+
+from sndr.model_configs.host import HostConfig, load_host_config
+from sndr.model_configs.host_autoinit import ensure_host_yaml
+from sndr.model_configs.types.docker import resolve_symbolic_mounts
+
+
+def _clear_host_env(monkeypatch):
+    for var in ("SNDR_MODELS_DIR", "GENESIS_MODELS_DIR", "SNDR_HF_CACHE",
+                "HF_HOME", "HUGGINGFACE_HUB_CACHE", "SNDR_HOME",
+                "GENESIS_HOME"):
+        monkeypatch.delenv(var, raising=False)
+
+
+def test_writes_detected_paths_on_first_miss(tmp_path, monkeypatch):
+    """Absent host.yaml -> detected paths get written; the renderer then
+    resolves ${models_dir} instead of leaving the literal token."""
+    _clear_host_env(monkeypatch)
+    models = tmp_path / "srv_models"
+    models.mkdir()
+    # Env override is the deterministic way to make detect_paths find a dir
+    # inside the tmp sandbox (also exercises the env-wins ladder at write).
+    monkeypatch.setenv("SNDR_MODELS_DIR", str(models))
+
+    host_yaml = tmp_path / ".sndr" / "host.yaml"
+    assert not host_yaml.exists()
+
+    written = ensure_host_yaml(path=host_yaml)
+    assert written == host_yaml
+    assert host_yaml.is_file(), "host.yaml must be created on first miss"
+
+    hc = load_host_config(host_yaml)
+    assert hc.get("models_dir") == str(models)
+
+    # Renderer no longer emits a literal ${models_dir}.
+    resolved = resolve_symbolic_mounts(
+        ["${models_dir}:/models:ro"], hc.paths, strict=False,
+    )
+    assert resolved == [f"{models}:/models:ro"]
+    assert "${models_dir}" not in resolved[0]
+
+
+def test_present_host_yaml_is_noop(tmp_path, monkeypatch):
+    """A present host.yaml is never touched (idempotent)."""
+    _clear_host_env(monkeypatch)
+    host_yaml = tmp_path / ".sndr" / "host.yaml"
+    host_yaml.parent.mkdir(parents=True)
+    original = "paths:\n  models_dir: /operator/custom/models\n"
+    host_yaml.write_text(original)
+
+    result = ensure_host_yaml(path=host_yaml)
+    assert result is None, "must no-op when host.yaml already exists"
+    assert host_yaml.read_text() == original, "existing file must be untouched"
+
+
+def test_idempotent_second_call(tmp_path, monkeypatch):
+    """Re-running after a write is a no-op (resumable / re-run safe)."""
+    _clear_host_env(monkeypatch)
+    models = tmp_path / "models"
+    models.mkdir()
+    monkeypatch.setenv("SNDR_MODELS_DIR", str(models))
+    host_yaml = tmp_path / ".sndr" / "host.yaml"
+
+    first = ensure_host_yaml(path=host_yaml)
+    assert first == host_yaml
+    snapshot = host_yaml.read_text()
+
+    second = ensure_host_yaml(path=host_yaml)
+    assert second is None
+    assert host_yaml.read_text() == snapshot
+
+
+def test_env_override_wins_into_written_file(tmp_path, monkeypatch):
+    """DOWNLOAD-3 ladder: a GENESIS_* env override pre-empts the probe list
+    and is what lands in the written host.yaml (env wins at write time)."""
+    _clear_host_env(monkeypatch)
+    env_models = tmp_path / "env_models"
+    env_models.mkdir()
+    monkeypatch.setenv("GENESIS_MODELS_DIR", str(env_models))
+
+    host_yaml = tmp_path / ".sndr" / "host.yaml"
+    ensure_host_yaml(path=host_yaml)
+
+    hc = load_host_config(host_yaml)
+    assert hc.get("models_dir") == str(env_models), (
+        "env override must win over default probe candidates in the written map"
+    )
+
+
+def test_nothing_detectable_writes_nothing(tmp_path, monkeypatch):
+    """On a host where detect_paths finds nothing, no stub file is written
+    (read-only / CI callers must not be polluted)."""
+    _clear_host_env(monkeypatch)
+    host_yaml = tmp_path / ".sndr" / "host.yaml"
+
+    import sndr.model_configs.host_autoinit as mod
+    monkeypatch.setattr(mod._host, "detect_paths", dict)
+
+    result = ensure_host_yaml(path=host_yaml)
+    assert result is None
+    assert not host_yaml.exists()
+
+
+def test_persist_false_detects_without_writing(tmp_path, monkeypatch):
+    """persist=False probes but never writes."""
+    _clear_host_env(monkeypatch)
+    models = tmp_path / "models"
+    models.mkdir()
+    monkeypatch.setenv("SNDR_MODELS_DIR", str(models))
+    host_yaml = tmp_path / ".sndr" / "host.yaml"
+
+    result = ensure_host_yaml(persist=False, path=host_yaml)
+    assert result == host_yaml, "would-write target is reported"
+    assert not host_yaml.exists(), "persist=False must not write"
+
+
+def test_load_host_config_autoinit_opt_out(tmp_path, monkeypatch):
+    """SNDR_HOST_AUTOINIT=0 keeps the legacy 'empty on absent' contract for
+    the default-path load (opt-out escape hatch)."""
+    _clear_host_env(monkeypatch)
+    monkeypatch.setenv("SNDR_HOME", str(tmp_path / ".sndr"))
+    monkeypatch.setenv("SNDR_HOST_AUTOINIT", "0")
+    models = tmp_path / "models"
+    models.mkdir()
+    monkeypatch.setenv("SNDR_MODELS_DIR", str(models))
+
+    hc = load_host_config()  # default path resolution, no host.yaml present
+    assert isinstance(hc, HostConfig)
+    assert not (tmp_path / ".sndr" / "host.yaml").exists(), (
+        "opt-out must not auto-write"
+    )

--- a/tests/unit/test_situation_docs_present.py
+++ b/tests/unit/test_situation_docs_present.py
@@ -1,0 +1,86 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Situation-doc presence + honesty gate.
+
+The UX-simplification wave (2026-07-06) added four per-hardware "front door"
+docs so a Mac / Windows / remote user is never left at a dead-end reading a
+Linux-only quickstart. This gate makes the wave's contract executable so it
+cannot silently rot:
+
+  1. all four situation docs exist;
+  2. every client-facing doc (Mac / Windows-WSL / remote) states the honest
+     hardware truth — the engine needs **Linux + CUDA** — so nobody is
+     promised a native-Mac / native-Windows engine;
+  3. every client-facing doc shows the remote-client env (at least
+     ``SNDR_OPENAI_BASE_URL``), and the canonical remote reference spells out
+     the full triplet;
+  4. each situation doc is reachable from BOTH the top-level ``README.md`` and
+     the ``docs/README.md`` index (an unlinked doc is dead weight).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parents[2]
+_DOCS = _REPO / "docs"
+
+# The four situation docs the wave introduced.
+_SITUATION_DOCS = (
+    "RUN_ON_LINUX.md",
+    "RUN_ON_MAC.md",
+    "RUN_ON_WINDOWS_WSL.md",
+    "REMOTE_ENGINE.md",
+)
+
+# Docs whose whole point is: you are NOT on a Linux+CUDA box, drive a rig.
+_CLIENT_DOCS = (
+    "RUN_ON_MAC.md",
+    "RUN_ON_WINDOWS_WSL.md",
+    "REMOTE_ENGINE.md",
+)
+
+_TRIPLET = ("SNDR_OPENAI_BASE_URL", "SNDR_ENGINE_API_KEY", "GENESIS_MEMORY_DSN")
+
+
+def test_situation_docs_exist():
+    missing = [d for d in _SITUATION_DOCS if not (_DOCS / d).is_file()]
+    assert not missing, f"missing situation docs: {missing}"
+
+
+def test_client_docs_state_the_linux_cuda_truth():
+    """No client doc may imply a native Mac/Windows engine."""
+    bad = []
+    for d in _CLIENT_DOCS:
+        text = (_DOCS / d).read_text(encoding="utf-8")
+        if "Linux + CUDA" not in text:
+            bad.append(d)
+    assert not bad, (
+        "client docs must state the engine needs 'Linux + CUDA' verbatim: "
+        f"{bad}"
+    )
+
+
+def test_client_docs_show_the_remote_base_url():
+    bad = [
+        d
+        for d in _CLIENT_DOCS
+        if "SNDR_OPENAI_BASE_URL" not in (_DOCS / d).read_text(encoding="utf-8")
+    ]
+    assert not bad, f"client docs missing SNDR_OPENAI_BASE_URL: {bad}"
+
+
+def test_remote_engine_doc_documents_the_full_triplet():
+    text = (_DOCS / "REMOTE_ENGINE.md").read_text(encoding="utf-8")
+    missing = [k for k in _TRIPLET if k not in text]
+    assert not missing, f"REMOTE_ENGINE.md missing triplet env vars: {missing}"
+
+
+def test_situation_docs_linked_from_readme_and_docs_index():
+    root_readme = (_REPO / "README.md").read_text(encoding="utf-8")
+    docs_index = (_DOCS / "README.md").read_text(encoding="utf-8")
+    unlinked = []
+    for d in _SITUATION_DOCS:
+        if d not in root_readme:
+            unlinked.append(f"README.md -> {d}")
+        if d not in docs_index:
+            unlinked.append(f"docs/README.md -> {d}")
+    assert not unlinked, f"situation docs not linked: {unlinked}"


### PR DESCRIPTION
## What & why

Newcomer onboarding was expert-only: to reach a working `curl` you had to know a preset key, a pin, a models dir, and that the engine only runs on Linux+CUDA. This branch adds a zero-decision front door on top of the existing expert surface — adapting club-3090's per-hardware front-door pattern to our stack. Nothing was removed: `sndr launch <preset>`, explicit `--pin`, all existing verbs and flags keep working unchanged.

## What got simpler (before -> after)

| Decision a new user faced | Before | After |
|---|---|---|
| Which preset? | pick a key from the registry by hand | `sndr quickstart` auto-detects GPUs, projects per-card VRAM, picks a fitting preset (explicit > pinned-default > top-fit) |
| Boot it | know `sndr launch <preset>` + flags | `sndr quickstart` delegates to `sndr up`; can save the pick as default |
| No Linux GPU (Mac/Windows)? | dead end | `sndr remote setup <url>` one-liner -> client mode against a remote rig; per-OS docs (RUN_ON_MAC / RUN_ON_WINDOWS_WSL) |
| Config | hand-write env | `.env.example` scaffold; `cp .env.example .env` boots on built-in defaults; host.yaml auto-init on first run |
| Install | one profile | `install.sh` auto-selects client vs full-stack by CUDA presence |

## Files

Added (nothing removed):
- CLI: `sndr/cli/user_prefs.py`, `sndr/cli/commands/quickstart.py`, `sndr/cli/commands/remote.py`
- Config: `.env.example`, `sndr/model_configs/host_autoinit.py`, `scripts/start_sndr_client.sh`
- Docs: `docs/RUN_ON_LINUX.md`, `docs/RUN_ON_MAC.md`, `docs/RUN_ON_WINDOWS_WSL.md`, `docs/REMOTE_ENGINE.md`
- Tests: 9 new test files (user_prefs, quickstart, chat remote-env, up remote/default, remote setup, env_example, host_autoinit, client_profile, situation_docs)

Edited (additive/corrective only): `sndr/cli/commands/{__init__,up,run,chat}.py`, `sndr/model_configs/host.py`, `install.sh`, `scripts/security_scan.py`, `.gitignore`, `README.md`, `docs/{GETTING_STARTED,QUICKSTART,README}.md`, `mkdocs.yml`, `tests/unit/scripts/test_security_scan.py`.

## Verification

- Full suite: 15065 passed, 586 skipped, 1 xfailed, 0 failed.
- `make_evidence` 65/65 green; `check_doc_sync --strict` clean (329 patches); `test_doc_preset_keys` 2/2.
- `audit-public-paths` clean (fixed a literal LAN IP in `remote.py` examples -> `<your-host>`).
- 0-new-ruff whole-file on all changed `.py` (ruff 0.15.11).
- Server-tested on the rig, PROD `vllm-35b-dev748` untouched: `sndr quickstart --dry-run --no-input` auto-detected OS + 2x A5000 via nvidia-smi and reached the boot decision with no manual config; `sndr remote setup` probed live PROD :8102 from the Mac (reachable); `install.sh --dry-run` (full-stack + client) scaffolded `.env` and host.yaml auto-init.

## Known follow-up (not blocking)

- Zero-decision default resolves to `prod-qwen3.6-35b-multiconc` (throughput-tuned, peak ~100% per-card VRAM) while README documents `prod-qwen3.6-35b-balanced` as the lone-user default. Reconcile the ranking bias or the doc claim in a fast-follow.
