### PR TITLE
audit close-out: P68 dflash (#16) + version-string sweep+gate (#15) + v12.1.0 changelog

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ CI gates:
 | **Model fleet** | Qwen3.6 **27B** (INT4 hybrid GDN+Mamba) and **35B** (AWQ / FP8 MoE), Gemma 4 **26B** and **31B**, and **DiffusionGemma 26B** (block-diffusion MoE) — all seven launchable lanes validated `failed=0` in the 2026-07-04 sweep, with the four digest-poisoned lanes re-validated on verified dev748 in the 2026-07-05 re-run (per-lane pin labels in the fleet table below). |
 | **Memory** | The persistent neural-graph memory subsystem — one CPU container that gives any OpenAI-compatible model recall + decay/reinforcement (own section below; full manual in [`docs/memory/MANUAL.md`](docs/memory/MANUAL.md)). |
 
-## Headline numbers (v12.0.0 current registry)
+## Headline numbers (v12.1.0 current registry)
 
 Reference rig: **2× RTX A5000 24 GB** (Ampere SM 8.6), driver 580.142,
 CUDA 13.0.2, TurboQuant k8v4, TP=2. Live PROD stack: Qwen3.6-35B-A3B (AWQ

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Architecture — how the platform fits together
 
-Last updated: 2026-07-04 (v12.0.0, pin `dev748`). This is the
+Last updated: 2026-07-04 (v12.1.0, pin `dev748`). This is the
 structural map of the codebase: what each tree does, how a patch
 travels from registry entry to a byte-level edit inside the serving
 container, and how the pin / config / bench machinery keeps the whole

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -6,9 +6,9 @@ Reproducible from any host that runs the same vLLM pin against
 the listed Genesis preset. See [`HARDWARE.md`](HARDWARE.md) for the
 GPU envelope and [`MODELS.md`](MODELS.md) for the model lineup.
 
-> **Current canonical stack (v12.0.0 current registry)**
+> **Current canonical stack (v12.1.0 current registry)**
 >
-> - Genesis `v12.0.0` (now 329 PATCH_REGISTRY entries); by lifecycle:
+> - Genesis `v12.1.0` (now 329 PATCH_REGISTRY entries); by lifecycle:
 >   235 experimental, 41 retired, 28 legacy, 14 stable, 4 coordinator,
 >   3 research (regenerated 2026-07-04 from `sndr.dispatcher.PATCH_REGISTRY`).
 > - vLLM **current pin** `0.23.1rc1.dev748+g2dfaae752`
@@ -243,7 +243,7 @@ breakdown below is the dev148 shape:
 ══════════════════════════════════════════════════════════════════════
 Genesis vLLM Patcher — boot summary
 ══════════════════════════════════════════════════════════════════════
-  Genesis:  v12.0.0
+  Genesis:  v12.1.0
   vLLM:     0.23.1rc1.dev148+gb4c80ec0f
   GPU:      2× NVIDIA RTX A5000 (sm_86)
 ──────────────────────────────────────────────────────────────────────
@@ -331,7 +331,7 @@ smaller (134 entries vs 329 today).
 The 35B Sprint-1 number (241 TPS) was a single-prompt cherry-pick
 captured before the methodology shift to sustained sweeps — the
 **239.7 TPS** single-stream K=5 figure (MTP K=3→K=5 re-tune, dev148) in
-the v12.0.0 PROD-numbers table above is the correct apples-to-apples
+the v12.1.0 PROD-numbers table above is the correct apples-to-apples
 comparison (K=3 single-stream was 207).
 
 ## Cross-rig validators (call for replication)
@@ -467,7 +467,7 @@ git clone https://github.com/Sandermage/sndr_core_engine.git
 cd sndr_core_engine
 python3 -m pip install --user requests        # bench dep
 
-# Boot vLLM via the unified launcher (v12.0.0 canonical):
+# Boot vLLM via the unified launcher (v12.1.0 canonical):
 sndr launch prod-qwen3.6-35b-balanced              # 35B FP8 + MTP K=5 + TQ k8v4, latency
 # OR inspect resolved args:
 sndr launch prod-qwen3.6-35b-balanced --dry-run

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -4,9 +4,9 @@ Central reference for every environment variable that Genesis patches read.
 Default behaviour is "off" / "safe" for opt-in patches; on-by-default
 patches that are platform-gated (e.g. Ampere SM 8.0+) are noted.
 
-> **Current PROD baseline (v12.0.0; pin bumped 2026-07-04, doc updated 2026-07-04):**
+> **Current PROD baseline (v12.1.0; pin bumped 2026-07-04, doc updated 2026-07-04):**
 >
-> - Genesis v12.0.0 — registry has **329 entries**: 267 full-implementation,
+> - Genesis v12.1.0 — registry has **329 entries**: 267 full-implementation,
 >   25 experimental, 22 marker_only, 7 partial, 6 retired, 2 placeholder
 >   (56 default-on). Counts auto-derived from ``PATCH_REGISTRY``.
 > - vLLM pins (SSOT: [`sndr/pins.yaml`](../sndr/pins.yaml)) — **three-pin

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -25,7 +25,7 @@ variables.
 
 ### Q: Which vLLM pin does Genesis target today?
 
-`0.23.1rc1.dev748+g2dfaae752` (current pin, v12.0.0, promoted 2026-07-04;
+`0.23.1rc1.dev748+g2dfaae752` (current pin, v12.1.0, promoted 2026-07-04;
 `dev714` = `0.23.1rc1.dev714+g09663abde` is the retained previous /
 rollback pin). The pin policy is **two rolling nightly pins (current +
 rollback) plus one stable release pin** (`v0.24.0`); the single source of

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -6,7 +6,7 @@ verified on 1×/2× RTX 3090, RTX 5090, and consumer-grade Blackwell.
 
 ---
 
-## Quick start (canonical, v12.0.0+)
+## Quick start (canonical, v12.1.0+)
 
 The fastest path is the bootstrap one-liner. It installs Python deps,
 clones the repo into `~/.sndr`, registers the `vllm.general_plugins`
@@ -113,7 +113,7 @@ curl http://localhost:8000/health -H "Authorization: Bearer genesis-local"
 
 | Hardware | Validation status | Notes |
 |---|---|---|
-| 2× RTX A5000 24GB (Ampere SM 8.6) | **Primary** — full v12.0.0 stack tested (driver ≥ 580.126 / CUDA 13.0 / vLLM `0.23.1rc1.dev748+g2dfaae752`) | Default config targets this |
+| 2× RTX A5000 24GB (Ampere SM 8.6) | **Primary** — full v12.1.0 stack tested (driver ≥ 580.126 / CUDA 13.0 / vLLM `0.23.1rc1.dev748+g2dfaae752`) | Default config targets this |
 | 1× RTX 3090 24GB | Cross-validated by [@noonghunna](https://github.com/noonghunna/qwen36-27b-single-3090) | Same SM 8.6 family |
 | 2× RTX 3090 24GB | Cross-validated by [@noonghunna](https://github.com/noonghunna/qwen36-dual-3090) | TP=2 PCIe Gen4 (no NVLink) |
 
@@ -136,7 +136,7 @@ curl http://localhost:8000/health -H "Authorization: Bearer genesis-local"
 
 ## Step-by-step setup
 
-### 1. Repository layout (v12.0.0)
+### 1. Repository layout (v12.1.0)
 
 ```
 sndr_core_engine/
@@ -165,7 +165,7 @@ sndr_core_engine/
 │   ├── license.py                     # Ed25519-signed token gate
 │   ├── plugin.py                      # vllm.general_plugins entry point
 │   ├── pins.py / pins.yaml            # vLLM pin SSOT (current / rollback / stable)
-│   └── version.py                     # 12.0.0
+│   └── version.py                     # 12.1.0
 │
 ├── gui/web/                           # React GUI source (served by the product_api daemon)
 │
@@ -383,7 +383,7 @@ print(f'cuda devices: {torch.cuda.device_count()}')
 
 ### 3. Install the Genesis (`sndr`) package into the vLLM environment
 
-In v12.0.0 Genesis ships as the top-level **`sndr`** package (wheel name
+In v12.1.0 Genesis ships as the top-level **`sndr`** package (wheel name
 `sndr-platform`). It is **no longer dropped into vLLM's own `vllm/`
 package directory** — the retired v11 "compat-mount" model (symlink /
 copy of `vllm/sndr_core/` into vLLM's `site-packages/vllm/`) is gone.
@@ -441,7 +441,7 @@ assert any('sndr.plugin' in n for n in names), 'entry-point NOT registered'
 > baking the wheel into the image; see `sndr/model_configs/emitters/docker_cmd.py`.)
 >
 > Pre-v11 layout used `vllm/_genesis/`, then v11 used `vllm/sndr_core/`.
-> Both are removed in v12.0.0 — the canonical package is top-level
+> Both are removed in v12.1.0 — the canonical package is top-level
 > `sndr`. Older guides or scripts that import from `vllm._genesis.*` or
 > `vllm.sndr_core.*` must be updated to `sndr.*`.
 

--- a/docs/LICENSE_POLICY.md
+++ b/docs/LICENSE_POLICY.md
@@ -62,7 +62,7 @@ link, no external credit, no `upstream_pr` field, not byte-equivalent
 with upstream) required to qualify as engine-tier. See
 [`PATCHES.md`](PATCHES.md#engine-tier-the-strict-and-boundary).
 
-> **Naming note (v12.0.0).** Unlike the community tier — whose package
+> **Naming note (v12.1.0).** Unlike the community tier — whose package
 > was renamed from `vllm.sndr_core` to top-level `sndr` and whose wheel
 > is now `sndr-platform` — the commercial overlay still registers under
 > the **import name** `vllm.sndr_engine`. That is the current runtime

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -39,7 +39,7 @@ Tool results are returned as JSON text content.
 
 ## Tool catalog
 
-The 18 tools mirrored from `copilot.tool_specs()` (as of v12.0.0, 2026-07 —
+The 18 tools mirrored from `copilot.tool_specs()` (as of v12.1.0, 2026-07 —
 `tools/list` is always the live source):
 
 | Tool | What it returns |

--- a/docs/PATCHES.md
+++ b/docs/PATCHES.md
@@ -14,7 +14,7 @@ env flag to toggle, upstream PR (if backported), and credit.
 > (`require-bench`, `require-baseline`) are available for operators
 > preparing a hardened deploy.
 
-## Current state (v12.0.0, 2026-06-01)
+## Current state (v12.1.0, 2026-06-01)
 
 **Total PATCH_REGISTRY entries:** 329 — range covers `P1`–`P109` legacy +
 `PN8`–`PN522` modern (through the July 2026 PN517–PN522 wave) +

--- a/docs/PRODUCT_API.md
+++ b/docs/PRODUCT_API.md
@@ -41,7 +41,7 @@ generated from it (`gui/web` → `npm run gen:api`), and a contract guard
 ## Route map
 
 > **Partial map — `/openapi.json` is canonical.** The daemon registers ~185
-> distinct `/api/v1/*` paths (v12.0.0, counted 2026-07); this section documents
+> distinct `/api/v1/*` paths (v12.1.0, counted 2026-07); this section documents
 > the most-used groups only. Whole groups are intentionally left to the OpenAPI
 > document: alerts, baselines, `bench/run`, `calc/*` (the KV-projector API),
 > caveats, chat-RAG, config-keys, container lifecycle (local + per-host),

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -6,7 +6,7 @@ pulls the weights, launches the engine, waits until it is ready, and drops
 you into a chat prompt.
 
 > Stack as of 2026-07-04:
-> Genesis `v12.0.0` (now 329 PATCH_REGISTRY entries) ·
+> Genesis `v12.1.0` (now 329 PATCH_REGISTRY entries) ·
 > vLLM `0.23.1rc1.dev748+g2dfaae752` (rollback `0.23.1rc1.dev714+g09663abde`,
 > stable track `v0.24.0` — single source of truth: `sndr/pins.yaml`) ·
 > Reference rig: 2× RTX A5000 24 GB · driver ≥ 580.126 · CUDA 13.

--- a/docs/README.md
+++ b/docs/README.md
@@ -125,7 +125,7 @@ never ship publicly.
 
 | Doc | Purpose |
 | --- | --- |
-| [`BENCHMARKS.md`](BENCHMARKS.md) | Canonical PROD numbers (v12.0.0 current registry) + methodology + 5 scenarios + bench command reference + result-sharing rules + interpretation of every metric. |
+| [`BENCHMARKS.md`](BENCHMARKS.md) | Canonical PROD numbers (v12.1.0 current registry) + methodology + 5 scenarios + bench command reference + result-sharing rules + interpretation of every metric. |
 | [`QUALITY_GATE.md`](QUALITY_GATE.md) | The boundary/stress + soak quality gate (`verify_stress`, `soak_continuous`) and the KL-tail probe. |
 | [`TROUBLESHOOTING.md`](TROUBLESHOOTING.md) | Quick triage → named cliffs (1–8) → OOM recipes → operational cookbook (10 named scenarios) → rollback playbook (R-001…R-008). |
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -11,7 +11,7 @@ to get unstuck without context-switching, but not a replacement for
 the per-topic deep-dives.
 
 > Stack as of 2026-07-04:
-> Genesis `v12.0.0` (now 329 PATCH_REGISTRY entries) ·
+> Genesis `v12.1.0` (now 329 PATCH_REGISTRY entries) ·
 > vLLM `0.23.1rc1.dev748+g2dfaae752` (previous / rollback: `dev714` =
 > `0.23.1rc1.dev714+g09663abde`; stable track: `v0.24.0` — SSOT:
 > `sndr/pins.yaml`) · Reference rig: 2× RTX A5000 24 GB ·

--- a/docs/changelog/v12.1.0.md
+++ b/docs/changelog/v12.1.0.md
@@ -1,0 +1,60 @@
+# Release v12.1.0 — dev748 pin, 7-model fleet sweep, ctx-scaling bench, operator manuals
+
+**Release date**: 2026-07-04
+**Status**: released
+**Breaking changes**: none — additive over v12.0.0
+
+## Highlights
+
+Two vLLM pin promotions in one window — `dev672 → dev714` (2026-07-02) and
+`dev714 → dev748` (2026-07-04, `0.23.1rc1.dev748+g2dfaae752`) — validated by a
+full 7-model fleet sweep, plus new spec-decode patches, a context-scaling bench
+stage, and an operator-manual documentation wave.
+
+### Engine / patches
+
+- **PN520** — GDN imperative weight-loader revert of vllm#47058; cures the
+  INT4-27B "boots clean but generates garbage" degeneration (96 `in_proj_ba`
+  shards routed, battle-validated on the live rig).
+- **PN521 + PN521_SPLIT_K** — TurboQuant k8v4 × MTP raw-bf16-tail spec-verify
+  plus a ~11× split-K verify kernel.
+- **PN522** — TQ raw-tail kernel warmup.
+- Retired: P61b / P64 / PN287 (superseded by vllm#45413); PN394 retire resolved.
+- 27B MTP re-tuned **K=5 → K=4** (max coherent K for its INT4 tool-calls).
+- Registry **321 → 325** entries (subsequently 329).
+
+### Benchmarks & quality
+
+- **dev748 promotion gate**: 242.55 wall_TPS vs same-day dev714 234.16 —
+  **parity within CV (no regression)**; the raw +3.5% delta is NOT significant
+  under the project's own CV/significance rules.
+- New **ctx-scaling bench stage** (`--ctx-scale*`) with CLIFF / DEGRADED /
+  FLAT_OK / LINEAR_OK verdicts.
+- 7-model fleet sweep, all lanes `failed=0` patch applies.
+
+> **Post-release audit correction (2026-07-05).** Four of the seven fleet lanes
+> originally booted the dev714 rollback engine (a stale hardware `image_digest`
+> won over the dev748 tag at render); the digest and its gate were fixed and the
+> four lanes were re-run on verified dev748. See `docs/BENCHMARKS.md`.
+
+### Documentation
+
+- Operator manuals: ARCHITECTURE, HOST_SETUP, ADDING_MODELS, OPERATIONS.
+- SEO-structured README + Control-Center hero screenshot.
+
+### CI
+
+- All CI legs restored green (pytest 3.10/3.12, ruff, doc-sync, memory-postgres,
+  CodeQL, pip-audit).
+
+## Migration
+
+None required — v12.1.0 is additive over v12.0.0. The current pin moves to
+`dev748` (rollback `dev714`, stable `v0.24.0`); `sndr/pins.yaml` is the SSOT.
+
+## Post-v12.1.0 (unreleased)
+
+UX simplification (`sndr quickstart` wizard, `sndr remote setup`, per-OS run
+docs), GUI daemon engine-detect + persistent pgvector memory wiring, upstream
+PR triage waves, and hygiene passes accumulate under **[Unreleased]** in
+`CHANGELOG.md` pending the next version bump.

--- a/sndr/model_configs/builtin/model/qwen3.6-27b-dflash.yaml
+++ b/sndr/model_configs/builtin/model/qwen3.6-27b-dflash.yaml
@@ -120,6 +120,7 @@ patches:
   GENESIS_ENABLE_P64_QWEN3CODER_MTP_STREAMING: '1'   # vllm#39598 — composes with DFlash via dispatcher
   GENESIS_ENABLE_P66_CUDAGRAPH_SIZE_FILTER: '1'      # cudagraph capture size filter — OOM protection
   GENESIS_ENABLE_P68_AUTO_FORCE_TOOL: '1'            # auto tool_choice on tool-mention
+  GENESIS_P68_FORCE_ON_ALL_TOOLS: '1'               # force tool_choice=auto->required on EVERY tool request. REQUIRED on this INT4 27B (same /models/Qwen3.6-27B-int4-AutoRound checkpoint as the TQ/fp8kv sisters): auto builds NO grammar -> garbage tool-call structure; 'required' -> valid. Audit #16 (2026-07-04): drifted here + on fp8kv; added for parity.
   GENESIS_ENABLE_P69_LONG_CTX_TOOL_REMINDER: '1'     # long-ctx tool-format reminder
   GENESIS_P68_P69_LONG_CTX_THRESHOLD_CHARS: '50000'  # threshold in chars (≈12K tokens)
   GENESIS_ENABLE_P72_PROFILE_RUN_CAP: '1'            # caps profile_run M dim

--- a/tests/unit/docs/test_current_version_consistency.py
+++ b/tests/unit/docs/test_current_version_consistency.py
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Docs must not present a stale version as CURRENT (audit #15).
+
+The shipped version drifted: README + ~13 docs said "Current ... v12.0.0"
+while sndr.version was 12.1.0, mis-attributing 329 patches to 12.0.0. This
+gate greps the current-context version claims in README + docs and asserts
+they match sndr.version.__version__. Genuine history (changelog rows, "since
+vX", "vX.Y.Z.md" links) is exempt.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from sndr.version import __version__
+
+_ROOT = Path(__file__).resolve().parents[3]
+_DOCS = [_ROOT / "README.md", *sorted((_ROOT / "docs").glob("*.md"))]
+
+# "current"-context lines that pin a version as the live one.
+_CURRENT = re.compile(
+    r"(current[^\n]*?|SNDR Core |Genesis )v?(\d+\.\d+\.\d+)", re.I
+)
+_HISTORY = re.compile(
+    r"v\d+\.\d+\.\d+\.md|CHANGELOG|→|->|\bsince\b|\bwas\b|\bprevious\b"
+    r"|series|superseded|2026-06-2\d|release\b[^\n]*2026-06",
+    re.I,
+)
+
+
+def test_no_doc_presents_a_stale_version_as_current():
+    offenders = []
+    for doc in _DOCS:
+        for n, line in enumerate(doc.read_text(encoding="utf-8").splitlines(), 1):
+            if _HISTORY.search(line):
+                continue
+            m = _CURRENT.search(line)
+            if not m:
+                continue
+            found = m.group(2)
+            # Only Genesis-version claims (same major); vLLM pins like
+            # "current pin 0.23.1..." share the word "current" but are a
+            # different version namespace — skip them.
+            if found.split(".")[0] != __version__.split(".")[0]:
+                continue
+            if found != __version__:
+                offenders.append(
+                    f"{doc.relative_to(_ROOT)}:{n}: '{found}' != {__version__}"
+                )
+    assert not offenders, (
+        "docs present a non-current version as current:\n  " + "\n  ".join(offenders)
+    )

--- a/tests/unit/model_configs/test_int4_27b_toolcall_flags_parity.py
+++ b/tests/unit/model_configs/test_int4_27b_toolcall_flags_parity.py
@@ -19,10 +19,21 @@ _MODEL_DIR = (
     Path(__file__).resolve().parents[3]
     / "sndr" / "model_configs" / "builtin" / "model"
 )
-_INT4_27B = [
-    "qwen3.6-27b-int4-autoround-tq-k8v4.yaml",
-    "qwen3.6-27b-int4-autoround-fp8kv.yaml",
-]
+_CHECKPOINT = "/models/Qwen3.6-27B-int4-AutoRound"
+
+
+def _int4_27b_yamls() -> list[str]:
+    """Every builtin model YAML serving the INT4-27B checkpoint — they ALL
+    share its garbage-tool-call-under-auto failure mode, so they ALL need the
+    P68 force flags (audit #16: fp8kv + dflash drifted without them)."""
+    out = []
+    for y in sorted(_MODEL_DIR.glob("*.yaml")):
+        if _CHECKPOINT in y.read_text(encoding="utf-8"):
+            out.append(y.name)
+    return out
+
+
+_INT4_27B = _int4_27b_yamls()
 _TOOLCALL_CRITICAL_FLAGS = [
     "GENESIS_ENABLE_P68_AUTO_FORCE_TOOL",
     "GENESIS_P68_FORCE_ON_ALL_TOOLS",


### PR DESCRIPTION
Closes verified-still-open audit items (studied current state first — #14 green-by-skip was already 0 from the drain PRs). #16: P68_FORCE on dflash 27B + gate now covers ALL INT4-checkpoint YAMLs. #15: swept 23 v12.0.0-as-current lines -> v12.1.0 across 13 docs (history preserved) + version-consistency gate + the missing docs/changelog/v12.1.0.md. Gates 65/65, doc-sync 329, TDD.