### PR TITLE
docs: broaden consumer-GPU story (4090/5090/dual-3090 FAQ + callout) + fix stale badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,18 @@
 > that works, **MTP speculative decoding**, and a **280K-token context** —
 > no fork, no rebuild.
 
+> 🎮 **Own a different card?** The 24 GiB envelope is class-wide, and `sndr up`
+> auto-projects VRAM for *your* GPU. **[RTX 4090](docs/FAQ.md#q-can-i-use-an-rtx-4090-instead-of-a-3090)** ·
+> **[RTX 5090 (32 GiB)](docs/FAQ.md#q-can-i-use-an-rtx-5090)** ·
+> **[dual RTX 3090](docs/FAQ.md#q-dual-rtx-3090--is-that-the-same-as-the-reference-rig)** —
+> honest per-class gotchas (Ampere-calibrated tuning, no-NVLink P2P, idle-VRAM headroom) in the FAQ.
+
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 [![Tests](https://github.com/Sandermage/sndr_core_engine/actions/workflows/test.yml/badge.svg)](https://github.com/Sandermage/sndr_core_engine/actions/workflows/test.yml)
 [![CodeQL](https://github.com/Sandermage/sndr_core_engine/actions/workflows/codeql.yml/badge.svg)](https://github.com/Sandermage/sndr_core_engine/actions/workflows/codeql.yml)
 [![vLLM pin](https://img.shields.io/badge/vllm-0.23.1rc1.dev748+g2dfaae752-orange.svg)](https://github.com/vllm-project/vllm)
 [![Patches](https://img.shields.io/badge/registry-329%20patches-green.svg)](docs/PATCHES.md)
-[![SNDR Core](https://img.shields.io/badge/SNDR%20Core-v12.0.0-blue.svg)](CHANGELOG.md)
+[![SNDR Core](https://img.shields.io/badge/SNDR%20Core-v12.1.0-blue.svg)](CHANGELOG.md)
 [![Memory](https://img.shields.io/badge/memory-neural--graph-ff69b4.svg)](docs/memory/MANUAL.md)
 [![GPU](https://img.shields.io/badge/GPU-A5000%20%7C%20RTX%204090%20%7C%205090%20%7C%203090%20%7C%20H20%20%7C%20R6000-purple.svg)](docs/HARDWARE.md)
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -84,6 +84,38 @@ TurboQuant k8v4 KV cache). Run `sndr preset list` or
 `sndr preset explain qa-qwen3.6-27b-tq-1x` to see the full card;
 [`SINGLE_CARD.md`](SINGLE_CARD.md) has the deep-dive.
 
+### Q: Can I use an RTX 4090 instead of a 3090?
+
+Yes. The 4090 (Ada, SM 8.9) clears the `compute_capability >= (8, 6)`
+kernel gate, so every Genesis patch that runs on the reference Ampere
+rig runs on a 4090 too — same 24 GiB envelope, same presets. Two
+honest caveats: (1) our numbers and VRAM budgets are **calibrated on
+Ampere (A5000/3090)** — a 4090 is faster on raw compute, so expect
+equal-or-better TPS, but verify the fit with `sndr quickstart` (it
+auto-projects VRAM for *your* card). (2) Consumer Ada has **no
+NVLink** — dual-4090 uses PCIe P2P like dual-3090, already the
+reference topology. Idle VRAM on the 4090 runs a touch tighter; if a
+280K-context preset sits at ~100% VRAM, drop to a `-balanced` preset
+or trim `--max-model-len`.
+
+### Q: Can I use an RTX 5090?
+
+Yes, with a bonus: the 5090 (Blackwell, SM 12.0) has a **32 GiB**
+envelope — more headroom than the 24 GiB reference, so long-context
+and multi-conc presets fit more comfortably. It clears the kernel gate
+and adds native FP8 paths. Caveat: SM 12.0 is **newer than the tuning
+target** — a few Triton autotune configs are Ampere-optimal, so treat
+the reference TPS as a floor and re-verify on your rig. A single 5090
+can run configs that need 2× 24 GiB cards on Ampere.
+
+### Q: Dual RTX 3090 — is that the same as the reference rig?
+
+Effectively yes. 2× 3090 (Ampere SM 8.6, 24 GiB each, PCIe P2P, no
+NVLink) is the **same class** as the 2× A5000 reference — the presets,
+patches, and VRAM budgets transfer directly. The 3090 draws more power
+(cap it with `nvidia-smi -pl` for a quieter homelab); otherwise
+`sndr up` auto-picks the same 2×24 GiB preset it would on the rig.
+
 ### Q: I have 2× 24 GiB cards — should I run 27B or 35B?
 
 Depends on workload. 35B-A3B (MoE) wins on prose quality and

--- a/docs/HARDWARE.md
+++ b/docs/HARDWARE.md
@@ -18,6 +18,18 @@ If your card is not listed and your workload is unusual, run `python3 -m sndr.co
 
 Most Genesis kernels gate on `compute_capability >= (8, 6)`. The dispatcher will print `[SKIP — pre-Ampere]` and fall back to upstream paths if you boot on Turing or earlier.
 
+**Per-class notes** (the FAQ has the full "can I use an X?" answers):
+- **RTX 3090 / A5000 (Ampere 8.6)** — the reference class. Presets, VRAM
+  budgets, and TPS numbers are calibrated here. Dual = PCIe P2P, no NVLink.
+- **RTX 4090 (Ada 8.9)** — same 24 GiB envelope, clears the kernel gate;
+  faster raw compute so expect ≥ reference TPS. No NVLink; idle VRAM a touch
+  tighter — verify long-context fit with `sndr quickstart`.
+  [→ FAQ](FAQ.md#q-can-i-use-an-rtx-4090-instead-of-a-3090)
+- **RTX 5090 (Blackwell 12.0)** — 32 GiB (more headroom), native FP8; a few
+  Triton autotune configs are Ampere-optimal, so treat reference TPS as a
+  floor. [→ FAQ](FAQ.md#q-can-i-use-an-rtx-5090)
+- **H100/H200, A100** — supported; data-center envelopes, not the tuning target.
+
 **Driver requirement:** NVIDIA driver **≥ 580.126.09 is REQUIRED** on the current CUDA 13 stack — the 570 series causes a ~3× slowdown (see [`CONFIGURATION.md`](CONFIGURATION.md) header).
 
 ## Will it fit? — builtin HardwareDefs + offline projection

--- a/tests/unit/docs/test_current_version_consistency.py
+++ b/tests/unit/docs/test_current_version_consistency.py
@@ -19,7 +19,8 @@ _DOCS = [_ROOT / "README.md", *sorted((_ROOT / "docs").glob("*.md"))]
 
 # "current"-context lines that pin a version as the live one.
 _CURRENT = re.compile(
-    r"(current[^\n]*?|SNDR Core |Genesis )v?(\d+\.\d+\.\d+)", re.I
+    r"(current[^\n]*?|SNDR[ %]20?Core[- ]|SNDR Core |Genesis )v?(\d+\.\d+\.\d+)",
+    re.I,
 )
 _HISTORY = re.compile(
     r"v\d+\.\d+\.\d+\.md|CHANGELOG|→|->|\bsince\b|\bwas\b|\bprevious\b"


### PR DESCRIPTION
Per the discoverability point: explicit honest per-card FAQ entries (RTX 4090 / 5090 / dual 3090) with real per-class gotchas (Ampere-calibrated tuning, no-NVLink P2P, 5090 32GiB headroom + SM 12.0 caveat), a README hero card-class callout (club-3090 pattern), HARDWARE per-class notes. Also fixes the URL-encoded SNDR Core badge the earlier v12.1.0 sweep missed + hardens the version gate. doc-sync green, version-consistency gate green.