### PR TITLE
feat(cli): sndr update — one-command 'keep me current + healthy' (pin-policy-safe)

### DIFF
--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -219,6 +219,35 @@ Show sndr-platform version and basic health info.
 sndr health
 ```
 
+### `sndr update` — **stable**
+
+One command to keep your install current and healthy. By default it is
+**read-only**: it reports your version, the engine pin, and whether the
+local repo is behind upstream, then tells you the single command to apply
+it. Pass `--apply` to actually fast-forward the product code and reinstall.
+
+It deliberately **never upgrades the engine pin** — the vLLM pin is
+content-addressed and changing it is an operator decision (bench + patch
+re-validation, see [`PIN_BUMP_PLAYBOOK.md`](PIN_BUMP_PLAYBOOK.md)). `sndr
+update` moves only the *product* (CLI + GUI + configs).
+
+```bash
+sndr update                     # report: version, pin, commits-behind (read-only)
+sndr update --apply             # fast-forward the repo + reinstall the package
+sndr update --no-fetch          # report from local refs only (offline)
+sndr update --json              # machine-readable status
+```
+
+| Flag | Default | Purpose |
+|---|---|---|
+| `--apply` | off | Actually pull the update + reinstall (default: just report). |
+| `-y`, `--yes` | off | Non-interactive: assume yes to prompts. |
+| `--no-fetch` | off | Skip the network fetch; report from local refs only. |
+| `--json` | off | Machine-readable status. |
+
+> Checking health specifically? `sndr doctor` runs the full
+> hardware + software + patches + drift diagnostic.
+
 ### `sndr tui` — **stable**
 
 Interactive terminal cockpit: one keyboard-driven screen showing the live engine

--- a/sndr/cli/commands/__init__.py
+++ b/sndr/cli/commands/__init__.py
@@ -26,6 +26,7 @@ from sndr.cli.commands.remote import RemoteSetupCommand
 from sndr.cli.commands.run import RunCommand
 from sndr.cli.commands.tui import TuiCommand
 from sndr.cli.commands.up import DownCommand, OpenCommand, UpCommand
+from sndr.cli.commands.update import UpdateCommand
 
 
 class Command(Protocol):
@@ -70,6 +71,8 @@ def build_subparsers(subparsers: argparse._SubParsersAction) -> None:
     # UX GROUP-CLI: wizard-first zero-config front door + remote client mode.
     register(QuickstartCommand())
     register(RemoteSetupCommand())
+    # One-command "keep me current + healthy" (product-only; engine pin gated).
+    register(UpdateCommand())
     register(PinsListCommand())
     register(HealthCommand())
     register(PreflightCommand())

--- a/sndr/cli/commands/update.py
+++ b/sndr/cli/commands/update.py
@@ -1,0 +1,208 @@
+# SPDX-License-Identifier: Apache-2.0
+"""CLI command: ``sndr update`` — the one-command "keep me current + healthy".
+
+The simple front door for updates. Under the hood the project has a lot of
+machinery (pin bumps, patch re-anchoring, drift audits); this command exposes
+the part a normal user cares about — *is my install current, and is it
+healthy?* — behind one verb.
+
+**Two things it deliberately does NOT do**, so it is safe to run any time:
+
+  * It never pulls a new **engine image**. The vLLM pin is content-addressed and
+    changing it is an operator decision (bench + patch re-validation); see
+    ``docs/PIN_BUMP_PLAYBOOK.md``. ``sndr update`` only moves the *product*
+    (CLI + GUI + configs) forward.
+  * Default (no ``--apply``) is **read-only**: it reports version, pin, and how
+    far the local repo is behind upstream, then tells you the one command to
+    apply it. Nothing is mutated until you pass ``--apply``.
+
+Design: the logic (home resolution, behind-count parsing, status rendering,
+apply sequence) is split into small pure/injectable helpers so it is testable
+offline without a network, a git checkout, or a real reinstall.
+"""
+from __future__ import annotations
+
+import argparse  # noqa: TC003 — runtime Namespace typing on the public execute() seam
+import json
+import os
+import subprocess
+import sys
+from collections.abc import Callable
+from pathlib import Path
+
+# A runner has the subprocess.run signature; injected in tests.
+Runner = Callable[..., "subprocess.CompletedProcess[str]"]
+
+DEFAULT_HOME = "~/.sndr"
+
+
+def _run(cmd: list[str], **kwargs) -> subprocess.CompletedProcess:
+    """Default command runner — real subprocess. Tests inject a fake."""
+    return subprocess.run(  # noqa: S603 — fixed argv lists, no shell
+        cmd, capture_output=True, text=True, check=False, **kwargs
+    )
+
+
+def _home_dir() -> Path:
+    """Resolve the sndr install directory — ``$SNDR_HOME`` or the ``~/.sndr``
+    default the installer uses."""
+    return Path(os.environ.get("SNDR_HOME", DEFAULT_HOME)).expanduser()
+
+
+def _behind_count(home: str | Path, *, runner: Runner = _run) -> int | None:
+    """How many commits the local checkout is behind its upstream branch.
+
+    Returns 0 when current, a positive int when behind, or ``None`` when it
+    can't be determined (no upstream, not a git repo, offline). Read-only:
+    it fetches and counts but never merges/pulls.
+    """
+    home = str(home)
+    # Refresh remote refs (best effort — offline just leaves the count stale).
+    runner(["git", "-C", home, "fetch", "--quiet"])
+    r = runner(["git", "-C", home, "rev-list", "--count", "HEAD..@{u}"])
+    if r.returncode != 0:
+        return None
+    out = (r.stdout or "").strip()
+    return int(out) if out.isdigit() else None
+
+
+def _installed_version() -> str:
+    try:
+        from sndr.version import __version__
+
+        return __version__
+    except Exception:  # pragma: no cover - defensive
+        return "unknown"
+
+
+def _engine_pin() -> str:
+    try:
+        from sndr import pins
+
+        return pins.current()
+    except Exception:  # pragma: no cover - defensive
+        return "unknown"
+
+
+def render_status(
+    *, version: str, pin: str, behind: int | None, home: str, applied: bool
+) -> str:
+    lines: list[str] = []
+    lines.append(f"sndr {version}   (install: {home})")
+    lines.append(f"engine pin: {pin}")
+    lines.append("")
+
+    if applied:
+        lines.append("✓ Updated to the latest product code and reinstalled.")
+    elif behind is None:
+        lines.append(
+            "Could not check for product updates (no upstream / offline). "
+            "Your install still works; run `sndr update --apply` when online."
+        )
+    elif behind == 0:
+        lines.append("✓ Product is up to date.")
+    else:
+        lines.append(
+            f"↑ {behind} commit(s) behind upstream. Apply the update with:"
+        )
+        lines.append("      sndr update --apply")
+
+    lines.append("")
+    lines.append(
+        "Note: the engine pin is NOT auto-upgraded — that is an operator "
+        "decision (bench + patch re-validation). See docs/PIN_BUMP_PLAYBOOK.md."
+    )
+    lines.append("Check health any time with:  sndr doctor")
+    return "\n".join(lines)
+
+
+def _apply_update(home: str | Path, *, runner: Runner = _run) -> int:
+    """Fast-forward the product repo and reinstall the package. Never touches
+    the engine image (pin policy)."""
+    home = str(home)
+    pull = runner(["git", "-C", home, "pull", "--ff-only", "--quiet"])
+    if pull.returncode != 0:
+        sys.stderr.write(
+            "update: `git pull --ff-only` failed — resolve local changes and "
+            f"retry.\n{(pull.stderr or '').strip()}\n"
+        )
+        return 1
+    reinstall = runner(
+        [sys.executable, "-m", "pip", "install", "--quiet", "--no-deps", "-e", home]
+    )
+    if reinstall.returncode != 0:
+        sys.stderr.write(
+            "update: editable reinstall failed.\n"
+            f"{(reinstall.stderr or '').strip()}\n"
+        )
+        return 1
+    return 0
+
+
+class UpdateCommand:
+    name = "update"
+    help = (
+        "Update the sndr install (CLI + GUI + configs) and re-check health. "
+        "Engine-pin upgrades stay operator-gated."
+    )
+
+    def configure_parser(self, parser: argparse.ArgumentParser) -> None:
+        parser.add_argument(
+            "--apply",
+            action="store_true",
+            help="Actually pull the update + reinstall (default: just report).",
+        )
+        parser.add_argument(
+            "-y",
+            "--yes",
+            action="store_true",
+            help="Non-interactive: assume yes to prompts.",
+        )
+        parser.add_argument(
+            "--no-fetch",
+            action="store_true",
+            help="Skip the network fetch; report from local refs only.",
+        )
+        parser.add_argument(
+            "--json", action="store_true", help="Machine-readable status."
+        )
+
+    def execute(self, args: argparse.Namespace) -> int:
+        home = _home_dir()
+        version = _installed_version()
+        pin = _engine_pin()
+
+        if getattr(args, "apply", False):
+            rc = _apply_update(home)
+            if rc != 0:
+                return rc
+            behind = 0
+            applied = True
+        else:
+            applied = False
+            behind = None if getattr(args, "no_fetch", False) else _behind_count(home)
+
+        if getattr(args, "json", False):
+            print(
+                json.dumps(
+                    {
+                        "version": version,
+                        "engine_pin": pin,
+                        "home": str(home),
+                        "behind": behind,
+                        "applied": applied,
+                    }
+                )
+            )
+            return 0
+
+        print(
+            render_status(
+                version=version,
+                pin=pin,
+                behind=behind,
+                home=str(home),
+                applied=applied,
+            )
+        )
+        return 0

--- a/tests/unit/cli/test_update_command.py
+++ b/tests/unit/cli/test_update_command.py
@@ -1,0 +1,155 @@
+# SPDX-License-Identifier: Apache-2.0
+"""`sndr update` — the one-command "keep my install current + healthy" front door.
+
+Contract:
+
+  * Registered on the curated dispatcher as `update`.
+  * DEFAULT (check) mode is read-only: it reports the installed version, the
+    engine pin, and whether the local repo is behind upstream — it MUST NOT
+    mutate anything and MUST NOT pull a new engine image (vLLM pin policy).
+  * `--apply` runs the product update (git fast-forward + editable reinstall)
+    via an injectable runner, then points at the integrity re-check.
+  * The status text always states that engine-pin changes are operator-gated,
+    so a user never mistakes `sndr update` for an engine upgrade.
+"""
+from __future__ import annotations
+
+import argparse
+
+import pytest
+
+pytest.importorskip("pydantic")
+
+from sndr.cli.commands import COMMAND_REGISTRY  # noqa: E402
+from sndr.cli.commands import update as update_mod  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _populate_registry():
+    """COMMAND_REGISTRY is filled by build_subparsers at parser-build time."""
+    from sndr.cli.main import build_parser
+
+    build_parser()
+
+
+def test_update_command_registered():
+    assert "update" in COMMAND_REGISTRY
+    cmd = COMMAND_REGISTRY["update"]
+    assert cmd.name == "update"
+    assert cmd.help
+
+
+def test_home_dir_respects_env(monkeypatch, tmp_path):
+    monkeypatch.setenv("SNDR_HOME", str(tmp_path))
+    assert update_mod._home_dir() == tmp_path
+
+
+def test_home_dir_defaults_when_unset(monkeypatch):
+    monkeypatch.delenv("SNDR_HOME", raising=False)
+    # Falls back to ~/.sndr — the install.sh default.
+    assert update_mod._home_dir().name == ".sndr"
+
+
+def test_render_status_shows_version_and_pin():
+    out = update_mod.render_status(
+        version="12.1.0", pin="0.23.1rc1.dev748", behind=0, home="/x", applied=False
+    )
+    assert "12.1.0" in out
+    assert "0.23.1rc1.dev748" in out
+    assert "up to date" in out.lower() or "up-to-date" in out.lower()
+
+
+def test_render_status_reports_behind_count():
+    out = update_mod.render_status(
+        version="12.1.0", pin="p", behind=3, home="/x", applied=False
+    )
+    assert "3" in out
+    assert "behind" in out.lower()
+
+
+def test_render_status_states_pin_policy():
+    """The output must make clear the engine pin is NOT auto-upgraded."""
+    out = update_mod.render_status(
+        version="12.1.0", pin="p", behind=0, home="/x", applied=False
+    )
+    low = out.lower()
+    assert "pin" in low
+    assert "operator" in low or "not " in low or "gated" in low
+
+
+def test_behind_count_parses_git_output():
+    calls = []
+
+    def fake_run(cmd, **kw):
+        calls.append(cmd)
+        # `git rev-list --count HEAD..@{u}` → number of upstream-ahead commits
+        class R:
+            returncode = 0
+            stdout = "4\n"
+        return R()
+
+    n = update_mod._behind_count("/repo", runner=fake_run)
+    assert n == 4
+    # It must have fetched then counted — never pulled/merged in check mode.
+    joined = " ".join(" ".join(c) for c in calls)
+    assert "rev-list" in joined
+    assert "pull" not in joined
+    assert "merge" not in joined
+
+
+def test_behind_count_unknown_on_error():
+    def fake_run(cmd, **kw):
+        class R:
+            returncode = 128
+            stdout = ""
+        return R()
+
+    assert update_mod._behind_count("/repo", runner=fake_run) is None
+
+
+def test_execute_check_mode_does_not_mutate(monkeypatch, tmp_path):
+    """Default execute() must never call the mutating runner."""
+    monkeypatch.setenv("SNDR_HOME", str(tmp_path))
+    mutations = []
+    monkeypatch.setattr(
+        update_mod, "_apply_update",
+        lambda *a, **k: mutations.append(a) or 0,
+    )
+    # No fetch → deterministic offline.
+    args = argparse.Namespace(apply=False, yes=False, json=False, no_fetch=True)
+    rc = COMMAND_REGISTRY["update"].execute(args)
+    assert rc == 0
+    assert mutations == [], "check mode must not apply an update"
+
+
+def test_execute_apply_invokes_update(monkeypatch, tmp_path):
+    monkeypatch.setenv("SNDR_HOME", str(tmp_path))
+    applied = []
+    monkeypatch.setattr(
+        update_mod, "_apply_update",
+        lambda *a, **k: applied.append(True) or 0,
+    )
+    args = argparse.Namespace(apply=True, yes=True, json=False, no_fetch=True)
+    rc = COMMAND_REGISTRY["update"].execute(args)
+    assert rc == 0
+    assert applied == [True]
+
+
+def test_apply_update_runs_pull_then_reinstall():
+    cmds = []
+
+    def fake_run(cmd, **kw):
+        cmds.append(cmd)
+        class R:
+            returncode = 0
+            stdout = ""
+        return R()
+
+    rc = update_mod._apply_update("/repo", runner=fake_run)
+    assert rc == 0
+    joined = [" ".join(c) for c in cmds]
+    # Must fast-forward pull the product repo AND reinstall the package.
+    assert any("pull" in c and "--ff-only" in c for c in joined), joined
+    assert any("pip" in c and "install" in c for c in joined), joined
+    # Policy: never pulls a docker/engine image.
+    assert not any("docker" in c and "pull" in c for c in joined)


### PR DESCRIPTION
## Why

Studying club-3090 (per the six-step Search→Compare rule) surfaced a concrete functional gap: they ship `scripts/update.sh` ("git pull + re-pin + re-vendor") — **we had no user-facing update front door at all**. A normal user had to know the git-pull + editable-reinstall dance. This adds one verb.

> Stacked on #74 (docs-accuracy). Base is that branch so this PR shows only its own diff.

## What `sndr update` does

```bash
sndr update                # report: version, engine pin, commits-behind (READ-ONLY)
sndr update --apply        # fast-forward the repo + reinstall the package
sndr update --no-fetch     # offline: report from local refs only
sndr update --json         # machine-readable
```

**Deliberately safe to run any time** — two guarantees:
1. **Read-only by default.** Nothing is mutated without `--apply`; the default just reports and prints the one command to apply.
2. **Never upgrades the engine pin.** The vLLM pin is content-addressed and operator-gated (bench + patch re-validation, per the pin policy + `PIN_BUMP_PLAYBOOK.md`). `sndr update` moves only the *product* (CLI + GUI + configs), and the status text says so explicitly so no one mistakes it for an engine upgrade. It never runs `docker pull`.

It points at `sndr doctor` for the full integrity/drift check — so "update + verify health" is two obvious commands.

## Design / TDD

Logic split into small pure/injectable helpers (`_home_dir`, `_behind_count`, `render_status`, `_apply_update`) so the whole flow is unit-tested **offline** — no network, git checkout, or real reinstall. `tests/unit/cli/test_update_command.py` (11 tests, red→green): registration, `$SNDR_HOME` resolution, behind-count parsing (fetch+rev-list, never pull/merge), status rendering, the pin-policy statement, check-mode-does-not-mutate, and the apply sequence (`pull --ff-only` + pip reinstall, asserts no `docker pull`).

## Verification
- ruff-clean on all new files; registered on the curated dispatcher (`sndr update --help` works)
- audit_public_docs ✓ · security_scan ✓ · 16 targeted tests green
- CLI_REFERENCE.md entry added (§1)