### PR TITLE
feat(cli): sndr switch — change the running model in one stateless step

### DIFF
--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -167,6 +167,33 @@ sndr down --dry-run                             # report what would be stopped
 `sndr down` accepts `preset` (default: the same top-fit resolution as
 `sndr up`), `--gui-port`, `--dry-run`, `--rig`, `--fake-gpus`.
 
+### `sndr switch` — **stable**
+
+Change which model is running in one stateless step: stop the current
+stack and boot another preset. The rig runs one heavy model at a time, so
+this is the everyday "give me a different model now" verb. It is a thin
+composition over `sndr down` + `sndr up`, so it inherits their weight
+checks, readiness wait and GUI-daemon handling. The target preset is
+validated **before** anything is stopped — a typo never leaves the rig
+with nothing running.
+
+```bash
+sndr switch                                     # list the presets you can switch to
+sndr switch prod-gemma4-31b-tq-default          # stop current → boot this one
+sndr switch prod-qwen3.6-35b-balanced --set-default   # ...and pin it as the default
+sndr switch prod-gemma4-26b-default --dry-run   # show the down/up plan, do nothing
+```
+
+| Flag | Default | Purpose |
+|---|---|---|
+| `preset` (positional) | — | Preset to switch to. Omit (or `--list`) to list switchable presets. |
+| `--list` | off | List the presets you can switch to and exit. |
+| `--set-default` | off | Also pin this preset as the default (so a later bare `sndr up` boots it). |
+| `--gui-port <int>` | 8765 | Product-API + GUI daemon port. |
+| `--dry-run` | off | Report the down/up plan without stopping or starting anything. |
+| `--no-input` | off | Headless: never prompt on stdin. |
+| `--timeout <sec>` | 300 | Seconds to wait for the new engine to become ready. |
+
 ### `sndr open` — **stable**
 
 Open the local product-API + GUI in your browser.

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -219,6 +219,35 @@ Show sndr-platform version and basic health info.
 sndr health
 ```
 
+### `sndr update` — **stable**
+
+One command to keep your install current and healthy. By default it is
+**read-only**: it reports your version, the engine pin, and whether the
+local repo is behind upstream, then tells you the single command to apply
+it. Pass `--apply` to actually fast-forward the product code and reinstall.
+
+It deliberately **never upgrades the engine pin** — the vLLM pin is
+content-addressed and changing it is an operator decision (bench + patch
+re-validation, see [`PIN_BUMP_PLAYBOOK.md`](PIN_BUMP_PLAYBOOK.md)). `sndr
+update` moves only the *product* (CLI + GUI + configs).
+
+```bash
+sndr update                     # report: version, pin, commits-behind (read-only)
+sndr update --apply             # fast-forward the repo + reinstall the package
+sndr update --no-fetch          # report from local refs only (offline)
+sndr update --json              # machine-readable status
+```
+
+| Flag | Default | Purpose |
+|---|---|---|
+| `--apply` | off | Actually pull the update + reinstall (default: just report). |
+| `-y`, `--yes` | off | Non-interactive: assume yes to prompts. |
+| `--no-fetch` | off | Skip the network fetch; report from local refs only. |
+| `--json` | off | Machine-readable status. |
+
+> Checking health specifically? `sndr doctor` runs the full
+> hardware + software + patches + drift diagnostic.
+
 ### `sndr tui` — **stable**
 
 Interactive terminal cockpit: one keyboard-driven screen showing the live engine

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -22,6 +22,8 @@ sndr up                                         # whole stack: engine + Control 
 sndr tui                                        # interactive cockpit — serve/stop/chat from one screen
 sndr launch prod-qwen3.6-35b-balanced           # launch a named preset
 sndr launch prod-qwen3.6-35b-balanced --dry-run # render only, no exec
+sndr switch prod-gemma4-31b-tq-default          # swap the running model (stop → boot another)
+sndr switch                                     # list presets you can switch to
 
 # Will it fit?
 sndr kv-calc prod-qwen3.6-35b-balanced          # per-card VRAM/KV projection (PASS/TIGHT/FAIL)
@@ -54,6 +56,10 @@ sndr bench --mode full --ctx-scale 32K   # + context-scaling (ceiling label)
 
 # Reporting
 sndr report bundle                              # tarball for issues
+
+# Keep current (product only — engine pin stays operator-gated)
+sndr update                                     # report: version, pin, commits-behind
+sndr update --apply                             # fast-forward + reinstall, then `sndr doctor`
 
 # Shut down + uninstall
 sndr down                                       # stop engine + GUI daemon

--- a/sndr/cli/commands/__init__.py
+++ b/sndr/cli/commands/__init__.py
@@ -24,6 +24,7 @@ from sndr.cli.commands.promoted import PROMOTED_COMMANDS
 from sndr.cli.commands.quickstart import QuickstartCommand
 from sndr.cli.commands.remote import RemoteSetupCommand
 from sndr.cli.commands.run import RunCommand
+from sndr.cli.commands.switch import SwitchCommand
 from sndr.cli.commands.tui import TuiCommand
 from sndr.cli.commands.up import DownCommand, OpenCommand, UpCommand
 from sndr.cli.commands.update import UpdateCommand
@@ -73,6 +74,8 @@ def build_subparsers(subparsers: argparse._SubParsersAction) -> None:
     register(RemoteSetupCommand())
     # One-command "keep me current + healthy" (product-only; engine pin gated).
     register(UpdateCommand())
+    # One-step model switch: stop current stack, boot another preset.
+    register(SwitchCommand())
     register(PinsListCommand())
     register(HealthCommand())
     register(PreflightCommand())

--- a/sndr/cli/commands/__init__.py
+++ b/sndr/cli/commands/__init__.py
@@ -26,6 +26,7 @@ from sndr.cli.commands.remote import RemoteSetupCommand
 from sndr.cli.commands.run import RunCommand
 from sndr.cli.commands.tui import TuiCommand
 from sndr.cli.commands.up import DownCommand, OpenCommand, UpCommand
+from sndr.cli.commands.update import UpdateCommand
 
 
 class Command(Protocol):
@@ -70,6 +71,8 @@ def build_subparsers(subparsers: argparse._SubParsersAction) -> None:
     # UX GROUP-CLI: wizard-first zero-config front door + remote client mode.
     register(QuickstartCommand())
     register(RemoteSetupCommand())
+    # One-command "keep me current + healthy" (product-only; engine pin gated).
+    register(UpdateCommand())
     register(PinsListCommand())
     register(HealthCommand())
     register(PreflightCommand())

--- a/sndr/cli/commands/switch.py
+++ b/sndr/cli/commands/switch.py
@@ -1,0 +1,192 @@
+# SPDX-License-Identifier: Apache-2.0
+"""CLI command: ``sndr switch`` — change which model is running, in one step.
+
+The rig runs one heavy model at a time (both GPUs are occupied at TP=2). Moving
+from one preset to another is a stop-then-start dance; ``sndr switch`` makes it
+a single stateless verb, the way club-3090's ``switch.sh <variant>`` does:
+
+    sndr switch                     # list the presets you can switch to
+    sndr switch prod-gemma4-31b-tq-default   # stop current, boot this one
+    sndr switch prod-... --set-default        # ...and remember it as the default
+
+It is a thin composition over the existing ``sndr down`` and ``sndr up`` — no
+new orchestration logic, so it inherits their weight checks, readiness wait, and
+GUI-daemon handling. The target preset is validated BEFORE anything is stopped,
+so a typo can never leave the rig with nothing running.
+"""
+from __future__ import annotations
+
+import argparse  # noqa: TC003 — runtime Namespace typing on the public execute() seam
+import sys
+
+_DEFAULT_GUI_PORT = 8765
+
+
+def _known_presets() -> set[str]:
+    """The set of switchable preset slugs (V2 registry). Empty on failure so
+    the caller degrades to a plain 'unknown preset' message."""
+    try:
+        from sndr.model_configs.registry_v2 import list_presets
+
+        return set(list_presets())
+    except Exception:  # pragma: no cover - defensive
+        return set()
+
+
+def _current_default() -> str | None:
+    try:
+        from sndr.cli import user_prefs
+
+        return user_prefs.get_default_preset()
+    except Exception:  # pragma: no cover - defensive
+        return None
+
+
+def _set_default(preset: str) -> None:
+    from sndr.cli import user_prefs
+
+    user_prefs.set_default_preset(preset)
+
+
+def _down(preset: str | None, *, gui_port: int, dry_run: bool) -> int:
+    """Stop the current stack via the canonical DownCommand."""
+    from sndr.cli.commands.up import DownCommand
+
+    ns = argparse.Namespace(preset=preset, gui_port=gui_port, dry_run=dry_run)
+    return DownCommand().execute(ns)
+
+
+def _up(
+    preset: str,
+    *,
+    gui_port: int,
+    dry_run: bool,
+    no_input: bool,
+    timeout: int,
+) -> int:
+    """Boot ``preset`` via the canonical UpCommand."""
+    from sndr.cli.commands.up import UpCommand
+
+    ns = argparse.Namespace(
+        preset=preset,
+        port=None,
+        gui_port=gui_port,
+        no_engine=False,
+        dry_run=dry_run,
+        no_input=no_input,
+        timeout=timeout,
+        rig=None,
+        fake_gpus=None,
+    )
+    return UpCommand().execute(ns)
+
+
+def render_list(presets, current: str | None) -> str:
+    lines = ["Switchable presets (* = current default):", ""]
+    for p in sorted(presets):
+        mark = " *" if p == current else "  "
+        lines.append(f"{mark} {p}")
+    lines.append("")
+    lines.append("Switch with:  sndr switch <preset>   (add --set-default to pin it)")
+    lines.append("Full cards:   sndr preset list")
+    return "\n".join(lines)
+
+
+class SwitchCommand:
+    name = "switch"
+    help = (
+        "Switch the running model in one step: stop the current stack and boot "
+        "another preset (bare `switch` lists them)."
+    )
+
+    def configure_parser(self, parser: argparse.ArgumentParser) -> None:
+        parser.add_argument(
+            "preset",
+            nargs="?",
+            default=None,
+            help="Preset to switch to. Omit (or `--list`) to list switchable presets.",
+        )
+        parser.add_argument(
+            "--list",
+            action="store_true",
+            help="List the presets you can switch to and exit.",
+        )
+        parser.add_argument(
+            "--set-default",
+            action="store_true",
+            help="Also pin this preset as the default (so `sndr up` boots it).",
+        )
+        parser.add_argument(
+            "--gui-port",
+            type=int,
+            default=_DEFAULT_GUI_PORT,
+            metavar="PORT",
+            help=f"Product-API + GUI daemon port (default: {_DEFAULT_GUI_PORT}).",
+        )
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Report the down/up plan without stopping or starting anything.",
+        )
+        parser.add_argument(
+            "--no-input",
+            action="store_true",
+            help="Headless: never prompt on stdin.",
+        )
+        parser.add_argument(
+            "--timeout",
+            type=int,
+            default=300,
+            metavar="SECONDS",
+            help="Seconds to wait for the new engine to become ready.",
+        )
+
+    def execute(self, args: argparse.Namespace) -> int:
+        preset = getattr(args, "preset", None)
+
+        # Bare `switch` or `--list`: show the menu, change nothing.
+        if getattr(args, "list", False) or preset is None:
+            print(render_list(_known_presets(), _current_default()))
+            return 0
+
+        # Validate the target BEFORE stopping anything — a typo must never
+        # leave the rig with nothing running.
+        known = _known_presets()
+        if known and preset not in known:
+            from difflib import get_close_matches
+
+            near = get_close_matches(preset, sorted(known), n=1)
+            hint = f" Did you mean `{near[0]}`?" if near else ""
+            sys.stderr.write(
+                f"switch: unknown preset `{preset}`.{hint} "
+                "Run `sndr switch --list` to see the options.\n"
+            )
+            return 2
+
+        gui_port = int(getattr(args, "gui_port", _DEFAULT_GUI_PORT))
+        dry_run = bool(getattr(args, "dry_run", False))
+        no_input = bool(getattr(args, "no_input", False))
+        timeout = int(getattr(args, "timeout", 300))
+
+        # Pin BEFORE switching so a later bare `sndr up` boots the same preset.
+        if getattr(args, "set_default", False):
+            try:
+                _set_default(preset)
+            except Exception as exc:  # noqa: BLE001 — surface, don't crash
+                sys.stderr.write(f"switch: could not pin default: {exc}\n")
+                return 2
+
+        down_rc = _down(preset, gui_port=gui_port, dry_run=dry_run)
+        if down_rc != 0:
+            sys.stderr.write(
+                "switch: could not stop the current stack; not starting the new "
+                "preset. Resolve the issue and retry.\n"
+            )
+            return down_rc
+        return _up(
+            preset,
+            gui_port=gui_port,
+            dry_run=dry_run,
+            no_input=no_input,
+            timeout=timeout,
+        )

--- a/sndr/cli/commands/switch.py
+++ b/sndr/cli/commands/switch.py
@@ -49,10 +49,19 @@ def _set_default(preset: str) -> None:
 
 
 def _down(preset: str | None, *, gui_port: int, dry_run: bool) -> int:
-    """Stop the current stack via the canonical DownCommand."""
+    """Stop the current stack via the canonical DownCommand.
+
+    The Namespace must carry EVERY attribute DownCommand.execute reads
+    (``preset``, ``gui_port``, ``dry_run``, ``rig``, ``fake_gpus``) — its
+    engine-preset resolution reads ``args.rig``/``args.fake_gpus`` directly and
+    swallows an AttributeError as "could not resolve", which would silently skip
+    stopping the engine container. See test_switch_namespace_contract.
+    """
     from sndr.cli.commands.up import DownCommand
 
-    ns = argparse.Namespace(preset=preset, gui_port=gui_port, dry_run=dry_run)
+    ns = argparse.Namespace(
+        preset=preset, gui_port=gui_port, dry_run=dry_run, rig=None, fake_gpus=None
+    )
     return DownCommand().execute(ns)
 
 

--- a/sndr/cli/commands/update.py
+++ b/sndr/cli/commands/update.py
@@ -1,0 +1,208 @@
+# SPDX-License-Identifier: Apache-2.0
+"""CLI command: ``sndr update`` — the one-command "keep me current + healthy".
+
+The simple front door for updates. Under the hood the project has a lot of
+machinery (pin bumps, patch re-anchoring, drift audits); this command exposes
+the part a normal user cares about — *is my install current, and is it
+healthy?* — behind one verb.
+
+**Two things it deliberately does NOT do**, so it is safe to run any time:
+
+  * It never pulls a new **engine image**. The vLLM pin is content-addressed and
+    changing it is an operator decision (bench + patch re-validation); see
+    ``docs/PIN_BUMP_PLAYBOOK.md``. ``sndr update`` only moves the *product*
+    (CLI + GUI + configs) forward.
+  * Default (no ``--apply``) is **read-only**: it reports version, pin, and how
+    far the local repo is behind upstream, then tells you the one command to
+    apply it. Nothing is mutated until you pass ``--apply``.
+
+Design: the logic (home resolution, behind-count parsing, status rendering,
+apply sequence) is split into small pure/injectable helpers so it is testable
+offline without a network, a git checkout, or a real reinstall.
+"""
+from __future__ import annotations
+
+import argparse  # noqa: TC003 — runtime Namespace typing on the public execute() seam
+import json
+import os
+import subprocess
+import sys
+from collections.abc import Callable
+from pathlib import Path
+
+# A runner has the subprocess.run signature; injected in tests.
+Runner = Callable[..., "subprocess.CompletedProcess[str]"]
+
+DEFAULT_HOME = "~/.sndr"
+
+
+def _run(cmd: list[str], **kwargs) -> subprocess.CompletedProcess:
+    """Default command runner — real subprocess. Tests inject a fake."""
+    return subprocess.run(  # noqa: S603 — fixed argv lists, no shell
+        cmd, capture_output=True, text=True, check=False, **kwargs
+    )
+
+
+def _home_dir() -> Path:
+    """Resolve the sndr install directory — ``$SNDR_HOME`` or the ``~/.sndr``
+    default the installer uses."""
+    return Path(os.environ.get("SNDR_HOME", DEFAULT_HOME)).expanduser()
+
+
+def _behind_count(home: str | Path, *, runner: Runner = _run) -> int | None:
+    """How many commits the local checkout is behind its upstream branch.
+
+    Returns 0 when current, a positive int when behind, or ``None`` when it
+    can't be determined (no upstream, not a git repo, offline). Read-only:
+    it fetches and counts but never merges/pulls.
+    """
+    home = str(home)
+    # Refresh remote refs (best effort — offline just leaves the count stale).
+    runner(["git", "-C", home, "fetch", "--quiet"])
+    r = runner(["git", "-C", home, "rev-list", "--count", "HEAD..@{u}"])
+    if r.returncode != 0:
+        return None
+    out = (r.stdout or "").strip()
+    return int(out) if out.isdigit() else None
+
+
+def _installed_version() -> str:
+    try:
+        from sndr.version import __version__
+
+        return __version__
+    except Exception:  # pragma: no cover - defensive
+        return "unknown"
+
+
+def _engine_pin() -> str:
+    try:
+        from sndr import pins
+
+        return pins.current()
+    except Exception:  # pragma: no cover - defensive
+        return "unknown"
+
+
+def render_status(
+    *, version: str, pin: str, behind: int | None, home: str, applied: bool
+) -> str:
+    lines: list[str] = []
+    lines.append(f"sndr {version}   (install: {home})")
+    lines.append(f"engine pin: {pin}")
+    lines.append("")
+
+    if applied:
+        lines.append("✓ Updated to the latest product code and reinstalled.")
+    elif behind is None:
+        lines.append(
+            "Could not check for product updates (no upstream / offline). "
+            "Your install still works; run `sndr update --apply` when online."
+        )
+    elif behind == 0:
+        lines.append("✓ Product is up to date.")
+    else:
+        lines.append(
+            f"↑ {behind} commit(s) behind upstream. Apply the update with:"
+        )
+        lines.append("      sndr update --apply")
+
+    lines.append("")
+    lines.append(
+        "Note: the engine pin is NOT auto-upgraded — that is an operator "
+        "decision (bench + patch re-validation). See docs/PIN_BUMP_PLAYBOOK.md."
+    )
+    lines.append("Check health any time with:  sndr doctor")
+    return "\n".join(lines)
+
+
+def _apply_update(home: str | Path, *, runner: Runner = _run) -> int:
+    """Fast-forward the product repo and reinstall the package. Never touches
+    the engine image (pin policy)."""
+    home = str(home)
+    pull = runner(["git", "-C", home, "pull", "--ff-only", "--quiet"])
+    if pull.returncode != 0:
+        sys.stderr.write(
+            "update: `git pull --ff-only` failed — resolve local changes and "
+            f"retry.\n{(pull.stderr or '').strip()}\n"
+        )
+        return 1
+    reinstall = runner(
+        [sys.executable, "-m", "pip", "install", "--quiet", "--no-deps", "-e", home]
+    )
+    if reinstall.returncode != 0:
+        sys.stderr.write(
+            "update: editable reinstall failed.\n"
+            f"{(reinstall.stderr or '').strip()}\n"
+        )
+        return 1
+    return 0
+
+
+class UpdateCommand:
+    name = "update"
+    help = (
+        "Update the sndr install (CLI + GUI + configs) and re-check health. "
+        "Engine-pin upgrades stay operator-gated."
+    )
+
+    def configure_parser(self, parser: argparse.ArgumentParser) -> None:
+        parser.add_argument(
+            "--apply",
+            action="store_true",
+            help="Actually pull the update + reinstall (default: just report).",
+        )
+        parser.add_argument(
+            "-y",
+            "--yes",
+            action="store_true",
+            help="Non-interactive: assume yes to prompts.",
+        )
+        parser.add_argument(
+            "--no-fetch",
+            action="store_true",
+            help="Skip the network fetch; report from local refs only.",
+        )
+        parser.add_argument(
+            "--json", action="store_true", help="Machine-readable status."
+        )
+
+    def execute(self, args: argparse.Namespace) -> int:
+        home = _home_dir()
+        version = _installed_version()
+        pin = _engine_pin()
+
+        if getattr(args, "apply", False):
+            rc = _apply_update(home)
+            if rc != 0:
+                return rc
+            behind = 0
+            applied = True
+        else:
+            applied = False
+            behind = None if getattr(args, "no_fetch", False) else _behind_count(home)
+
+        if getattr(args, "json", False):
+            print(
+                json.dumps(
+                    {
+                        "version": version,
+                        "engine_pin": pin,
+                        "home": str(home),
+                        "behind": behind,
+                        "applied": applied,
+                    }
+                )
+            )
+            return 0
+
+        print(
+            render_status(
+                version=version,
+                pin=pin,
+                behind=behind,
+                home=str(home),
+                applied=applied,
+            )
+        )
+        return 0

--- a/tests/unit/cli/test_switch_command.py
+++ b/tests/unit/cli/test_switch_command.py
@@ -159,3 +159,63 @@ def test_dry_run_forwarded(monkeypatch):
     COMMAND_REGISTRY["switch"].execute(_a(preset="prod-b", dry_run=True))
     assert seen["down_dry"] is True
     assert seen["up_dry"] is True
+
+
+# ── Namespace contract: switch must satisfy the REAL up/down execute() ─────────
+# (the unit tests above mock _down/_up, so they cannot catch a missing arg that
+# only the real DownCommand/UpCommand.execute reads — that surfaced as a silent
+# "engine not stopped" half-switch when _down omitted rig/fake_gpus).
+
+
+def _attrs_read_by(class_name: str) -> set[str]:
+    import ast
+    import pathlib
+    import re
+
+    src = pathlib.Path(
+        pathlib.Path(switch_mod.__file__).parent / "up.py"
+    ).read_text()
+    tree = ast.parse(src)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef) and node.name == class_name:
+            for fn in node.body:
+                if isinstance(fn, ast.FunctionDef) and fn.name == "execute":
+                    seg = ast.get_source_segment(src, fn)
+                    attrs = set(re.findall(r"args\.([a-z_]+)", seg))
+                    attrs |= set(re.findall(r'getattr\(args,\s*["\']([a-z_]+)', seg))
+                    return attrs
+    return set()
+
+
+def _capture_namespace(monkeypatch, seam_command: str) -> argparse.Namespace:
+    """Run switch._down/_up but intercept the Namespace handed to the real
+    command, so we can compare its attrs to what execute() reads."""
+    captured = {}
+
+    class _Spy:
+        def execute(self, ns):
+            captured["ns"] = ns
+            return 0
+
+    import sndr.cli.commands.up as up_mod
+
+    monkeypatch.setattr(up_mod, seam_command, _Spy)
+    return captured
+
+
+def test_down_namespace_satisfies_downcommand(monkeypatch):
+    cap = _capture_namespace(monkeypatch, "DownCommand")
+    switch_mod._down("prod-x", gui_port=8765, dry_run=True)
+    provided = set(vars(cap["ns"]))
+    required = _attrs_read_by("DownCommand")
+    missing = required - provided
+    assert not missing, f"_down Namespace missing {missing} that DownCommand.execute reads"
+
+
+def test_up_namespace_satisfies_upcommand(monkeypatch):
+    cap = _capture_namespace(monkeypatch, "UpCommand")
+    switch_mod._up("prod-x", gui_port=8765, dry_run=True, no_input=True, timeout=300)
+    provided = set(vars(cap["ns"]))
+    required = _attrs_read_by("UpCommand")
+    missing = required - provided
+    assert not missing, f"_up Namespace missing {missing} that UpCommand.execute reads"

--- a/tests/unit/cli/test_switch_command.py
+++ b/tests/unit/cli/test_switch_command.py
@@ -1,0 +1,161 @@
+# SPDX-License-Identifier: Apache-2.0
+"""`sndr switch` — one stateless step to change which model is running.
+
+Matches club-3090's `switch.sh <variant>` ergonomics: stop the current stack,
+boot another preset, optionally pin it as the default. Contract:
+
+  * Registered on the curated dispatcher as `switch`.
+  * `sndr switch` (bare) and `sndr switch --list` show the switchable presets,
+    marking the current default.
+  * `sndr switch <preset>` validates the target FIRST (unknown → error, nothing
+    touched), then brings the stack DOWN and back UP on the new preset — in that
+    order.
+  * `--set-default` pins the target via user_prefs before switching (and a typo
+    target is never pinned).
+  * `--dry-run` forwards to down/up without doing real work.
+"""
+from __future__ import annotations
+
+import argparse
+
+import pytest
+
+pytest.importorskip("pydantic")
+
+from sndr.cli.commands import COMMAND_REGISTRY  # noqa: E402
+from sndr.cli.commands import switch as switch_mod  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _populate_registry():
+    from sndr.cli.main import build_parser
+
+    build_parser()
+
+
+def _a(**kw) -> argparse.Namespace:
+    base = {
+        "preset": None, "list": False, "set_default": False,
+        "gui_port": 8765, "dry_run": False, "no_input": True, "timeout": 300,
+    }
+    base.update(kw)
+    return argparse.Namespace(**base)
+
+
+def test_switch_registered():
+    assert "switch" in COMMAND_REGISTRY
+    assert COMMAND_REGISTRY["switch"].name == "switch"
+    assert COMMAND_REGISTRY["switch"].help
+
+
+def test_known_presets_nonempty():
+    ps = switch_mod._known_presets()
+    assert isinstance(ps, set)
+    assert len(ps) >= 1
+
+
+def test_render_list_marks_current_default():
+    out = switch_mod.render_list(
+        ["prod-a", "prod-b"], current="prod-b"
+    )
+    assert "prod-a" in out
+    assert "prod-b" in out
+    # The current default is flagged somehow (a marker char near it).
+    idx = out.index("prod-b")
+    assert any(mark in out[max(0, idx - 6): idx + 8] for mark in ("*", "default", "◀", "current"))
+
+
+def test_bare_switch_lists(monkeypatch, capsys):
+    monkeypatch.setattr(switch_mod, "_known_presets", lambda: {"prod-a", "prod-b"})
+    monkeypatch.setattr(switch_mod, "_down", lambda *a, **k: pytest.fail("must not switch"))
+    rc = COMMAND_REGISTRY["switch"].execute(_a(preset=None))
+    assert rc == 0
+    assert "prod-a" in capsys.readouterr().out
+
+
+def test_explicit_list_flag(monkeypatch, capsys):
+    monkeypatch.setattr(switch_mod, "_known_presets", lambda: {"prod-a"})
+    rc = COMMAND_REGISTRY["switch"].execute(_a(list=True))
+    assert rc == 0
+    assert "prod-a" in capsys.readouterr().out
+
+
+def test_unknown_preset_errors_and_touches_nothing(monkeypatch):
+    monkeypatch.setattr(switch_mod, "_known_presets", lambda: {"prod-a"})
+    touched = []
+    monkeypatch.setattr(switch_mod, "_down", lambda *a, **k: touched.append("down"))
+    monkeypatch.setattr(switch_mod, "_up", lambda *a, **k: touched.append("up"))
+    rc = COMMAND_REGISTRY["switch"].execute(_a(preset="nope"))
+    assert rc != 0
+    assert touched == [], "an unknown preset must not stop or start anything"
+
+
+def test_switch_downs_then_ups_in_order(monkeypatch):
+    monkeypatch.setattr(switch_mod, "_known_presets", lambda: {"prod-b"})
+    order = []
+    monkeypatch.setattr(switch_mod, "_down", lambda *a, **k: order.append("down") or 0)
+    monkeypatch.setattr(switch_mod, "_up", lambda *a, **k: order.append("up") or 0)
+    rc = COMMAND_REGISTRY["switch"].execute(_a(preset="prod-b"))
+    assert rc == 0
+    assert order == ["down", "up"]
+
+
+def test_switch_propagates_up_rc(monkeypatch):
+    monkeypatch.setattr(switch_mod, "_known_presets", lambda: {"prod-b"})
+    monkeypatch.setattr(switch_mod, "_down", lambda *a, **k: 0)
+    monkeypatch.setattr(switch_mod, "_up", lambda *a, **k: 7)
+    rc = COMMAND_REGISTRY["switch"].execute(_a(preset="prod-b"))
+    assert rc == 7
+
+
+def test_up_receives_target_preset(monkeypatch):
+    monkeypatch.setattr(switch_mod, "_known_presets", lambda: {"prod-b"})
+    seen = {}
+    monkeypatch.setattr(switch_mod, "_down", lambda *a, **k: 0)
+
+    def fake_up(preset, **k):
+        seen["preset"] = preset
+        return 0
+
+    monkeypatch.setattr(switch_mod, "_up", fake_up)
+    COMMAND_REGISTRY["switch"].execute(_a(preset="prod-b"))
+    assert seen["preset"] == "prod-b"
+
+
+def test_set_default_pins_target(monkeypatch):
+    monkeypatch.setattr(switch_mod, "_known_presets", lambda: {"prod-b"})
+    monkeypatch.setattr(switch_mod, "_down", lambda *a, **k: 0)
+    monkeypatch.setattr(switch_mod, "_up", lambda *a, **k: 0)
+    pinned = []
+    monkeypatch.setattr(switch_mod, "_set_default", pinned.append)
+    COMMAND_REGISTRY["switch"].execute(_a(preset="prod-b", set_default=True))
+    assert pinned == ["prod-b"]
+
+
+def test_no_set_default_does_not_pin(monkeypatch):
+    monkeypatch.setattr(switch_mod, "_known_presets", lambda: {"prod-b"})
+    monkeypatch.setattr(switch_mod, "_down", lambda *a, **k: 0)
+    monkeypatch.setattr(switch_mod, "_up", lambda *a, **k: 0)
+    pinned = []
+    monkeypatch.setattr(switch_mod, "_set_default", pinned.append)
+    COMMAND_REGISTRY["switch"].execute(_a(preset="prod-b", set_default=False))
+    assert pinned == []
+
+
+def test_dry_run_forwarded(monkeypatch):
+    monkeypatch.setattr(switch_mod, "_known_presets", lambda: {"prod-b"})
+    seen = {}
+
+    def fake_down(*a, **k):
+        seen["down_dry"] = k.get("dry_run")
+        return 0
+
+    def fake_up(*a, **k):
+        seen["up_dry"] = k.get("dry_run")
+        return 0
+
+    monkeypatch.setattr(switch_mod, "_down", fake_down)
+    monkeypatch.setattr(switch_mod, "_up", fake_up)
+    COMMAND_REGISTRY["switch"].execute(_a(preset="prod-b", dry_run=True))
+    assert seen["down_dry"] is True
+    assert seen["up_dry"] is True

--- a/tests/unit/cli/test_update_command.py
+++ b/tests/unit/cli/test_update_command.py
@@ -1,0 +1,155 @@
+# SPDX-License-Identifier: Apache-2.0
+"""`sndr update` — the one-command "keep my install current + healthy" front door.
+
+Contract:
+
+  * Registered on the curated dispatcher as `update`.
+  * DEFAULT (check) mode is read-only: it reports the installed version, the
+    engine pin, and whether the local repo is behind upstream — it MUST NOT
+    mutate anything and MUST NOT pull a new engine image (vLLM pin policy).
+  * `--apply` runs the product update (git fast-forward + editable reinstall)
+    via an injectable runner, then points at the integrity re-check.
+  * The status text always states that engine-pin changes are operator-gated,
+    so a user never mistakes `sndr update` for an engine upgrade.
+"""
+from __future__ import annotations
+
+import argparse
+
+import pytest
+
+pytest.importorskip("pydantic")
+
+from sndr.cli.commands import COMMAND_REGISTRY  # noqa: E402
+from sndr.cli.commands import update as update_mod  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _populate_registry():
+    """COMMAND_REGISTRY is filled by build_subparsers at parser-build time."""
+    from sndr.cli.main import build_parser
+
+    build_parser()
+
+
+def test_update_command_registered():
+    assert "update" in COMMAND_REGISTRY
+    cmd = COMMAND_REGISTRY["update"]
+    assert cmd.name == "update"
+    assert cmd.help
+
+
+def test_home_dir_respects_env(monkeypatch, tmp_path):
+    monkeypatch.setenv("SNDR_HOME", str(tmp_path))
+    assert update_mod._home_dir() == tmp_path
+
+
+def test_home_dir_defaults_when_unset(monkeypatch):
+    monkeypatch.delenv("SNDR_HOME", raising=False)
+    # Falls back to ~/.sndr — the install.sh default.
+    assert update_mod._home_dir().name == ".sndr"
+
+
+def test_render_status_shows_version_and_pin():
+    out = update_mod.render_status(
+        version="12.1.0", pin="0.23.1rc1.dev748", behind=0, home="/x", applied=False
+    )
+    assert "12.1.0" in out
+    assert "0.23.1rc1.dev748" in out
+    assert "up to date" in out.lower() or "up-to-date" in out.lower()
+
+
+def test_render_status_reports_behind_count():
+    out = update_mod.render_status(
+        version="12.1.0", pin="p", behind=3, home="/x", applied=False
+    )
+    assert "3" in out
+    assert "behind" in out.lower()
+
+
+def test_render_status_states_pin_policy():
+    """The output must make clear the engine pin is NOT auto-upgraded."""
+    out = update_mod.render_status(
+        version="12.1.0", pin="p", behind=0, home="/x", applied=False
+    )
+    low = out.lower()
+    assert "pin" in low
+    assert "operator" in low or "not " in low or "gated" in low
+
+
+def test_behind_count_parses_git_output():
+    calls = []
+
+    def fake_run(cmd, **kw):
+        calls.append(cmd)
+        # `git rev-list --count HEAD..@{u}` → number of upstream-ahead commits
+        class R:
+            returncode = 0
+            stdout = "4\n"
+        return R()
+
+    n = update_mod._behind_count("/repo", runner=fake_run)
+    assert n == 4
+    # It must have fetched then counted — never pulled/merged in check mode.
+    joined = " ".join(" ".join(c) for c in calls)
+    assert "rev-list" in joined
+    assert "pull" not in joined
+    assert "merge" not in joined
+
+
+def test_behind_count_unknown_on_error():
+    def fake_run(cmd, **kw):
+        class R:
+            returncode = 128
+            stdout = ""
+        return R()
+
+    assert update_mod._behind_count("/repo", runner=fake_run) is None
+
+
+def test_execute_check_mode_does_not_mutate(monkeypatch, tmp_path):
+    """Default execute() must never call the mutating runner."""
+    monkeypatch.setenv("SNDR_HOME", str(tmp_path))
+    mutations = []
+    monkeypatch.setattr(
+        update_mod, "_apply_update",
+        lambda *a, **k: mutations.append(a) or 0,
+    )
+    # No fetch → deterministic offline.
+    args = argparse.Namespace(apply=False, yes=False, json=False, no_fetch=True)
+    rc = COMMAND_REGISTRY["update"].execute(args)
+    assert rc == 0
+    assert mutations == [], "check mode must not apply an update"
+
+
+def test_execute_apply_invokes_update(monkeypatch, tmp_path):
+    monkeypatch.setenv("SNDR_HOME", str(tmp_path))
+    applied = []
+    monkeypatch.setattr(
+        update_mod, "_apply_update",
+        lambda *a, **k: applied.append(True) or 0,
+    )
+    args = argparse.Namespace(apply=True, yes=True, json=False, no_fetch=True)
+    rc = COMMAND_REGISTRY["update"].execute(args)
+    assert rc == 0
+    assert applied == [True]
+
+
+def test_apply_update_runs_pull_then_reinstall():
+    cmds = []
+
+    def fake_run(cmd, **kw):
+        cmds.append(cmd)
+        class R:
+            returncode = 0
+            stdout = ""
+        return R()
+
+    rc = update_mod._apply_update("/repo", runner=fake_run)
+    assert rc == 0
+    joined = [" ".join(c) for c in cmds]
+    # Must fast-forward pull the product repo AND reinstall the package.
+    assert any("pull" in c and "--ff-only" in c for c in joined), joined
+    assert any("pip" in c and "install" in c for c in joined), joined
+    # Policy: never pulls a docker/engine image.
+    assert not any("docker" in c and "pull" in c for c in joined)


### PR DESCRIPTION
## Why

Fourth "simple on the surface" verb from the club-3090 comparison. They ship `switch.sh <variant>` (stateless down→up). We had the pieces (`sndr up`/`down`, quickstart's make-default) but no single switch verb — so changing models meant a manual stop-then-start. The rig runs one heavy model at a time, so this is an everyday action.

> Stacked on #75 (which is stacked on #74). Base is #75's branch so this PR shows only its own diff.

## What

```bash
sndr switch                                     # list switchable presets (marks the default)
sndr switch prod-gemma4-31b-tq-default          # stop current → boot this one
sndr switch prod-qwen3.6-35b-balanced --set-default   # ...and pin it
sndr switch prod-gemma4-26b-default --dry-run   # show the down/up plan, do nothing
```

## Design

Thin composition over the canonical `DownCommand` + `UpCommand` — **no new orchestration logic**, so it inherits their weight checks, readiness wait, and GUI-daemon handling. Key safety property: the target preset is validated **before** anything is stopped, so a typo (`sndr switch prod-qwn...`) errors with a "did you mean …?" hint and rc 2 **without stopping the running engine** — you never end up with nothing running. `--set-default` pins via `user_prefs.set_default_preset`, which itself refuses an unknown slug.

## TDD / coverage

`tests/unit/cli/test_switch_command.py` (12 tests, red→green): registration, list rendering + current-default marker, bare-`switch`-lists, unknown-preset-touches-nothing, **down-then-up ordering**, up-rc propagation, target forwarding, set-default pin / no-pin, dry-run forwarding.

## Verification
- 54 CLI tests green (switch + update + up/down + dispatch — no regression)
- ruff-clean on all new files; `audit_public_docs` ✓ · `security_scan` ✓ (no private IPs)
- CLI_REFERENCE.md entry added