### PR TITLE
feat(memory): cognitive memory-type taxonomy (working/episodic/semantic/procedural) with type-aware decay

### DIFF
--- a/sndr/cli/commands/mem.py
+++ b/sndr/cli/commands/mem.py
@@ -89,7 +89,12 @@ class MemRememberCommand:
 
     def configure_parser(self, parser: argparse.ArgumentParser) -> None:
         parser.add_argument("text", help="the text to remember")
-        parser.add_argument("--kind", default="note", help="node kind (default: note)")
+        parser.add_argument(
+            "--kind", default="note",
+            help="memory type — working (fades in ~30 min), episodic (~1 day), "
+                 "semantic (~1 week), procedural (~1 month); drives how fast it "
+                 "decays. Any other value keeps the neutral 1-day rate (default: note).",
+        )
         parser.add_argument("--importance", type=float, default=0.0,
                             help="seed importance in [0,1] (default: 0.0)")
         _add_connection_args(parser)

--- a/sndr/memory/model.py
+++ b/sndr/memory/model.py
@@ -21,6 +21,40 @@ HEBBIAN_LAMBDA: float = 0.995  # retention (1 - decay) per co-access step
 # S is the base memory-strength time-constant in seconds; importance scales it.
 EBBINGHAUS_S: float = 86_400.0  # 1 day base half-life scale
 
+# ── Cognitive memory taxonomy (working / episodic / semantic / procedural).
+# The brain forgets different kinds of memory at very different rates: a
+# working-memory scratchpad fades in minutes, an episode over a day or two, a
+# learned fact over weeks, a skill barely at all. Each type scales the base
+# Ebbinghaus time-constant `S` by its factor (applied once in store._retention,
+# so both backends stay identical). ANY other/legacy kind ("note",
+# "conversation", …) maps to 1.0 — exactly the pre-taxonomy behaviour, so
+# nothing already stored changes.
+MEMORY_TYPES: tuple[str, ...] = ("working", "episodic", "semantic", "procedural")
+DEFAULT_MEMORY_TYPE: str = "episodic"  # a captured experience is episodic by default
+
+TYPE_DECAY_FACTOR: dict[str, float] = {
+    "working": 0.02,      # ~30 min half-life — the current-context scratchpad
+    "episodic": 1.0,      # ~1 day — an experience/event (the historical baseline)
+    "semantic": 8.0,      # ~1 week — a consolidated fact/concept
+    "procedural": 30.0,   # ~1 month — a learned skill / how-to (persists longest)
+}
+
+
+def type_decay_factor(kind: str) -> float:
+    """Ebbinghaus time-constant multiplier for a memory kind. Unknown/legacy
+    kinds return 1.0 (neutral — the pre-taxonomy behaviour)."""
+    return TYPE_DECAY_FACTOR.get(kind, 1.0)
+
+
+def normalize_memory_type(value: str | None) -> str:
+    """Coerce a user-supplied type to a canonical one, defaulting to episodic.
+    Never raises — a bad value degrades to the default rather than blocking a
+    write."""
+    if not value:
+        return DEFAULT_MEMORY_TYPE
+    v = str(value).strip().lower()
+    return v if v in MEMORY_TYPES else DEFAULT_MEMORY_TYPE
+
 # ── Spreading activation along the graph during expand (design section 3).
 SPREAD_DAMPING: float = 0.5   # beta: score multiplier per hop
 MAX_EXPAND_DEPTH: int = 3     # bounded traversal (cycle-safe)

--- a/sndr/memory/store.py
+++ b/sndr/memory/store.py
@@ -22,7 +22,12 @@ import time
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any
 
-from sndr.memory.model import EBBINGHAUS_S, SPREAD_DAMPING, SearchHit
+from sndr.memory.model import (
+    EBBINGHAUS_S,
+    SPREAD_DAMPING,
+    SearchHit,
+    type_decay_factor,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Iterator, Sequence
@@ -127,14 +132,23 @@ class MemoryStore(ABC):
         """
 
     def _retention(self, node: MemoryNode, now: float) -> float:
-        """Ebbinghaus retention R = exp(-age / (S * strength * (1 + importance))).
+        """Ebbinghaus retention
+        R = exp(-age / (S * type_factor * strength * (1 + importance))).
 
-        `strength` is the reinforcement base (grows with retrieval, see _touch),
-        so frequently-recalled memories decay slower — the spacing effect.
+        `type_factor` is the cognitive-taxonomy multiplier (working forgets fast,
+        procedural slow; unknown/legacy kinds = 1.0, so decay is unchanged for
+        anything already stored). `strength` is the reinforcement base (grows
+        with retrieval, see _touch), so frequently-recalled memories decay
+        slower — the spacing effect.
         """
         age = max(0.0, now - node.accessed_at)
         strength = node.strength if node.strength and node.strength > 0 else 1.0
-        scale = EBBINGHAUS_S * strength * (1.0 + max(0.0, node.importance))
+        scale = (
+            EBBINGHAUS_S
+            * type_decay_factor(node.kind)
+            * strength
+            * (1.0 + max(0.0, node.importance))
+        )
         return math.exp(-age / scale)
 
     def recall(

--- a/sndr/product_api/schemas/memory.py
+++ b/sndr/product_api/schemas/memory.py
@@ -9,7 +9,12 @@ from pydantic import BaseModel, Field
 
 class RememberIn(BaseModel):
     text: str = Field(min_length=1)
-    kind: str = "note"
+    kind: str = Field(
+        default="note",
+        description="Memory type driving decay rate: working (~30 min), "
+        "episodic (~1 day), semantic (~1 week), procedural (~1 month). "
+        "Any other value keeps the neutral 1-day rate.",
+    )
     importance: float = 0.0
     properties: dict[str, Any] = Field(default_factory=dict)
 

--- a/tests/unit/test_memory_types.py
+++ b/tests/unit/test_memory_types.py
@@ -1,0 +1,97 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Typed memory taxonomy — the cognitive working / episodic / semantic /
+procedural distinction, and its effect on the Ebbinghaus decay time-constant.
+
+The brain does not forget all memories at the same rate: a working-memory
+scratchpad fades in minutes, an episode over days, a learned fact over weeks, a
+skill barely at all. Before this, every node decayed on the same 1-day base
+constant regardless of what kind of memory it was. This gives each memory TYPE
+its own decay multiplier, applied at the single shared `_retention` seam so both
+backends stay numerically identical.
+
+Regression safety: any *unknown* kind (the historical "note"/"conversation"
+values, and the contract-test default "note") maps to factor 1.0 — i.e. exactly
+the previous behaviour — so nothing already stored changes.
+"""
+from __future__ import annotations
+
+import math
+
+from sndr.memory import model
+
+
+def test_canonical_memory_types_defined():
+    assert model.MEMORY_TYPES == ("working", "episodic", "semantic", "procedural")
+
+
+def test_type_decay_factor_ordering():
+    """working forgets fastest, procedural slowest — a strict ladder."""
+    f = model.type_decay_factor
+    assert f("working") < f("episodic") < f("semantic") < f("procedural")
+
+
+def test_working_memory_is_short_lived():
+    """Working memory's factor is well under a day (fast-expiring scratchpad)."""
+    assert model.type_decay_factor("working") < 0.1
+
+
+def test_unknown_kind_is_neutral_factor_one():
+    """No regression: legacy/unknown kinds decay exactly as before (factor 1.0)."""
+    assert model.type_decay_factor("note") == 1.0
+    assert model.type_decay_factor("conversation") == 1.0
+    assert model.type_decay_factor("") == 1.0
+    assert model.type_decay_factor("something-new") == 1.0
+
+
+def test_normalize_type_accepts_canonical_and_defaults():
+    assert model.normalize_memory_type("semantic") == "semantic"
+    assert model.normalize_memory_type("SEMANTIC") == "semantic"
+    # An unrecognized value falls back to the episodic default, never crashes.
+    assert model.normalize_memory_type("nonsense") == "episodic"
+    assert model.normalize_memory_type(None) == "episodic"
+
+
+# ── decay behaviour through the real store seam ───────────────────────────────
+
+
+def _node(kind: str) -> model.MemoryNode:
+    return model.MemoryNode(
+        id=1, owner_id=1, kind=kind, content="x",
+        strength=1.0, importance=0.0, accessed_at=0.0,
+    )
+
+
+def _retention(store, node, now):
+    return store._retention(node, now)
+
+
+def test_working_decays_faster_than_semantic_at_same_age():
+    from sndr.memory.inmemory import InMemoryStore
+
+    store = InMemoryStore()
+    age = model.EBBINGHAUS_S  # one base time-constant of elapsed time
+    r_working = _retention(store, _node("working"), age)
+    r_semantic = _retention(store, _node("semantic"), age)
+    assert r_working < r_semantic
+
+
+def test_note_retention_unchanged_vs_manual_formula():
+    """The historical 'note' path must still equal the bare Ebbinghaus formula."""
+    from sndr.memory.inmemory import InMemoryStore
+
+    store = InMemoryStore()
+    age = 3600.0
+    expected = math.exp(-age / (model.EBBINGHAUS_S * 1.0 * 1.0))  # strength=1, imp=0
+    assert abs(_retention(store, _node("note"), age) - expected) < 1e-9
+
+
+def test_remember_accepts_and_stores_memory_type():
+    from sndr.memory.embedder import HashEmbedder
+    from sndr.memory.engine import MemoryEngine
+    from sndr.memory.inmemory import InMemoryStore
+
+    eng = MemoryEngine(store=InMemoryStore(), embedder=HashEmbedder(dim=64))
+    nid = eng.remember(owner_id=1, text="Paris is the capital of France",
+                       kind="semantic")
+    node = eng.store.get_node(nid)
+    assert node.kind == "semantic"


### PR DESCRIPTION
## Why

First slice of the **memory-as-brain** uplift. A 53-agent adversarial study of `sndr/memory/` against its 4 design docs + 2026 SOTA (mem0 / Letta / Zep-Graphiti / cognee / A-MEM) + cognitive-memory theory confirmed **47 real gaps** (only 1 candidate dismissed as already-built — the engine is genuinely sophisticated: Hebbian co-access, Ebbinghaus decay, spreading-activation recall, semantic auto-linking, communities, bi-temporal edges, Obsidian import, pgvector backend all already shipped).

The **biggest brain gap**: the engine is a strong *associative* store but has no *typed-memory* half. `MemoryNode.kind` existed but **nothing ever branched on it**, so a working-memory scratchpad and a learned skill decayed at the same 1-day rate.

## What

Adds the classic cognitive taxonomy — **working / episodic / semantic / procedural** — and wires it into the one place that makes memory brain-like: the Ebbinghaus decay time-constant.

| Type | Factor | Half-life | Meaning |
|---|---|---|---|
| working | ×0.02 | ~30 min | current-context scratchpad |
| episodic | ×1 | ~1 day | an experience/event (historical baseline) |
| semantic | ×8 | ~1 week | a consolidated fact/concept |
| procedural | ×30 | ~1 month | a learned skill / how-to |

Reachable **today** via the existing `kind` field: `sndr mem remember "Paris is the capital of France" --kind semantic` now decays ~8× slower than a conversation turn. CLI `--kind` help + the API `RememberIn` schema document the four types.

## Regression-safe by construction

The multiplier is applied **once** in the shared `store._retention` (both backends stay numerically identical), and **any unknown/legacy kind** — `note`, `conversation`, the contract-test default — maps to **factor 1.0**, i.e. exactly the pre-taxonomy decay. Proven: full in-memory contract suite (44) green; a test pins the `note` path to the bare Ebbinghaus formula.

## TDD

`tests/unit/test_memory_types.py` (8 tests, red→green): taxonomy constants, strict decay-factor ladder, unknown→1.0 neutrality, working-vs-semantic decay through the real store seam, note-path formula parity, `normalize_memory_type`, and `remember()` storing the type.

## Verification
- 1064 passed / 147 skipped (Postgres+V1 fixtures) — full memory + CLI regression clean
- ruff-clean on all changed files

## Follow-ups (from the study, tracked in memory)
reflection/insight synthesis that CREATES nodes · working-memory tier · LLM fact-extraction + typed entity/relation KG on write · automated contradiction→invalidation · Obsidian bidirectional export + path-keyed identity + frontmatter · CLI/GUI/TUI surface coherence (`sndr switch` in GUI/TUI, brain-tier verbs in CLI).