### PR TITLE
feat(memory): expose brain-tier verbs (consolidate/neighbors/forget/import) on the sndr mem CLI

### DIFF
--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -752,18 +752,31 @@ python3 scripts/bump_pin.py 0.23.1rc1.devNNN+g<sha> \
 ## 7. Memory daemon (`mem.*`)
 
 Persistent memory (graph + vector) served by the running product-API
-daemon (`sndr up`, port 8765). All four verbs share `--url` (else
+daemon (`sndr up`, port 8765). Every verb shares `--url` (else
 `$SNDR_MEMORY_URL` / `$SNDR_GUI_URL`, default `http://127.0.0.1:8765`),
 `--owner` (else `$SNDR_MEMORY_OWNER`, default 1) and `--token` (else
 `$GENESIS_MEMORY_API_KEY`, sent as Bearer).
 
 ```bash
+# store / retrieve
 sndr mem.remember "the 27B rig uses TP=2"       # store a memory
+sndr mem.remember "Paris is the capital of France" --kind semantic   # typed (slow-decay) fact
 sndr mem.recall "27B rig"                       # graph expand + reinforce
 sndr mem.search "TP settings"                   # vector/hybrid search, no side effects
-sndr mem.stats                                  # node/edge counts for this owner
+sndr mem.stats                                  # node/edge/community counts
 sndr mem                                        # bare group → mem.stats
+
+# brain tier (was GUI/API-only before)
+sndr mem.consolidate                            # auto-link + detect communities + rank importance
+sndr mem.neighbors 42                           # graph connections of node 42
+sndr mem.forget 42                              # delete a memory + its edges
+sndr mem.import MyVault                          # import an Obsidian vault (notes+wikilinks)
 ```
+
+`--kind` selects the cognitive memory type — `working` (~30 min), `episodic`
+(~1 day), `semantic` (~1 week), `procedural` (~1 month) — which sets how fast
+the memory decays. `mem.import` reads a vault under the daemon's
+`GENESIS_MEMORY_VAULT_ROOT`.
 
 ---
 

--- a/sndr/cli/commands/__init__.py
+++ b/sndr/cli/commands/__init__.py
@@ -13,6 +13,10 @@ from sndr.cli.commands.health import HealthCommand
 from sndr.cli.commands.kv_calc import KvCalcCommand
 from sndr.cli.commands.launch import LaunchCommand
 from sndr.cli.commands.mem import (
+    MemConsolidateCommand,
+    MemForgetCommand,
+    MemImportCommand,
+    MemNeighborsCommand,
     MemRecallCommand,
     MemRememberCommand,
     MemSearchCommand,
@@ -85,6 +89,11 @@ def build_subparsers(subparsers: argparse._SubParsersAction) -> None:
     register(MemRecallCommand())
     register(MemSearchCommand())
     register(MemStatsCommand())
+    # Brain-tier verbs — reachable from the terminal, not just GUI/API.
+    register(MemConsolidateCommand())
+    register(MemNeighborsCommand())
+    register(MemForgetCommand())
+    register(MemImportCommand())
     # TUI cockpit (read-only Phase 1) — the command gates on the optional [tui]
     # extra (textual) with a friendly install hint when it's absent.
     register(TuiCommand())

--- a/sndr/cli/commands/mem.py
+++ b/sndr/cli/commands/mem.py
@@ -173,7 +173,96 @@ class MemStatsCommand:
         return _run(args, _do)
 
 
+class MemConsolidateCommand:
+    name = "mem.consolidate"
+    help = "Run brain maintenance: semantic auto-link + communities + importance."
+
+    def configure_parser(self, parser: argparse.ArgumentParser) -> None:
+        parser.add_argument("--tau", type=float, default=0.8,
+                            help="semantic-link cosine threshold (default: 0.8)")
+        parser.add_argument("--k", type=int, default=10,
+                            help="kNN neighbours per node for linking (default: 10)")
+        _add_connection_args(parser)
+
+    def execute(self, args: argparse.Namespace) -> int:
+        def _do(client) -> int:
+            rep = client.consolidate(owner_id=_owner(args), tau=args.tau, k=args.k)
+            if getattr(args, "output", "text") == "json":
+                print(json.dumps(rep))
+            else:
+                print(f"consolidated: {rep.get('linked', 0)} links, "
+                      f"{rep.get('communities', 0)} communities over "
+                      f"{rep.get('nodes', 0)} nodes")
+            return 0
+        return _run(args, _do)
+
+
+class MemNeighborsCommand:
+    name = "mem.neighbors"
+    help = "List the nodes adjacent to a memory node (its graph connections)."
+
+    def configure_parser(self, parser: argparse.ArgumentParser) -> None:
+        parser.add_argument("node_id", type=int, help="node id to inspect")
+        _add_connection_args(parser)
+
+    def execute(self, args: argparse.Namespace) -> int:
+        def _do(client) -> int:
+            rows = client.neighbors(owner_id=_owner(args), node_id=args.node_id)
+            if getattr(args, "output", "text") == "json":
+                print(json.dumps(rows))
+            elif not rows:
+                print(f"node {args.node_id}: no neighbours")
+            else:
+                for r in rows:
+                    print(f"  {r.get('id')}  {r.get('rel'):<12} w={r.get('weight'):.3f}")
+            return 0
+        return _run(args, _do)
+
+
+class MemForgetCommand:
+    name = "mem.forget"
+    help = "Forget (delete) a memory node and its edges via the running daemon."
+
+    def configure_parser(self, parser: argparse.ArgumentParser) -> None:
+        parser.add_argument("node_id", type=int, help="node id to forget")
+        _add_connection_args(parser)
+
+    def execute(self, args: argparse.Namespace) -> int:
+        def _do(client) -> int:
+            out = client.forget(owner_id=_owner(args), node_id=args.node_id)
+            if getattr(args, "output", "text") == "json":
+                print(json.dumps(out))
+            else:
+                print(f"forgot node {out.get('id', args.node_id)}")
+            return 0
+        return _run(args, _do)
+
+
+class MemImportCommand:
+    name = "mem.import"
+    help = "Import an Obsidian vault (notes+wikilinks) into memory via the daemon."
+
+    def configure_parser(self, parser: argparse.ArgumentParser) -> None:
+        parser.add_argument("path", help="vault directory, relative to the daemon's "
+                                         "allowed vault root (GENESIS_MEMORY_VAULT_ROOT)")
+        _add_connection_args(parser)
+
+    def execute(self, args: argparse.Namespace) -> int:
+        def _do(client) -> int:
+            rep = client.import_obsidian(owner_id=_owner(args), path=args.path)
+            if getattr(args, "output", "text") == "json":
+                print(json.dumps(rep))
+            else:
+                print(f"imported: {rep.get('notes', 0)} notes, {rep.get('links', 0)} links")
+            return 0
+        return _run(args, _do)
+
+
 __all__ = [
+    "MemConsolidateCommand",
+    "MemForgetCommand",
+    "MemImportCommand",
+    "MemNeighborsCommand",
     "MemRecallCommand",
     "MemRememberCommand",
     "MemSearchCommand",

--- a/sndr/memory/client.py
+++ b/sndr/memory/client.py
@@ -110,3 +110,32 @@ class MemoryHTTPClient:
     def stats(self, *, owner_id: int) -> dict[str, int]:
         """Owner memory counts: ``{"nodes": int, "edges": int}``."""
         return self._call("GET", "/api/v1/memory/stats", owner=owner_id)
+
+    # ── brain-tier verbs (were GUI/API-only before) ──────────────────────────
+    def consolidate(
+        self, *, owner_id: int, tau: float = 0.8, k: int = 10
+    ) -> dict[str, int]:
+        """Run the batch brain maintenance: semantic auto-link + community
+        detection + importance recompute. Returns ``{linked, communities, nodes}``."""
+        return self._call(
+            "POST", "/api/v1/memory/consolidate", {"tau": tau, "k": k}, owner=owner_id
+        )
+
+    def neighbors(self, *, owner_id: int, node_id: int) -> list[dict[str, Any]]:
+        """Adjacent nodes of ``node_id``: ``[{id, rel, weight}, ...]``."""
+        return self._call(
+            "GET", f"/api/v1/memory/neighbors/{node_id}", owner=owner_id
+        )
+
+    def forget(self, *, owner_id: int, node_id: int) -> dict[str, Any]:
+        """Delete a memory node (and its edges). Returns ``{deleted, id}``."""
+        return self._call(
+            "DELETE", f"/api/v1/memory/node/{node_id}", owner=owner_id
+        )
+
+    def import_obsidian(self, *, owner_id: int, path: str) -> dict[str, int]:
+        """Import an Obsidian vault (relative to the daemon's allowed root) into
+        memory: notes -> nodes, [[wikilinks]] -> edges. Returns ``{notes, links}``."""
+        return self._call(
+            "POST", "/api/v1/memory/import/obsidian", {"path": path}, owner=owner_id
+        )

--- a/tests/unit/test_memory_cli_verbs.py
+++ b/tests/unit/test_memory_cli_verbs.py
@@ -1,0 +1,158 @@
+# SPDX-License-Identifier: Apache-2.0
+"""CLI/client coherence: the brain-tier memory verbs must be reachable from the
+terminal, not just the GUI/API.
+
+Before this the `sndr mem` surface was remember/recall/search/stats only — an
+operator could not consolidate, inspect a node's neighbours, forget a memory, or
+import an Obsidian vault without hand-rolling HTTP. These four verbs close that
+gap over the EXISTING API routes (POST /consolidate, GET /neighbors/{id},
+DELETE /node/{id}, POST /import/obsidian).
+"""
+from __future__ import annotations
+
+import argparse
+
+import pytest
+
+pytest.importorskip("pydantic")
+
+from sndr.cli.commands import COMMAND_REGISTRY  # noqa: E402
+from sndr.memory.client import MemoryHTTPClient  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _registry():
+    from sndr.cli.main import build_parser
+
+    build_parser()
+
+
+# ── client methods construct the right (method, path, body) ───────────────────
+
+
+def _spy_client():
+    calls = []
+    c = MemoryHTTPClient("http://x", owner_id=1)
+
+    def fake_call(method, path, body=None, owner=None):
+        calls.append((method, path, body, owner))
+        # Return shapes the methods expect.
+        if "consolidate" in path:
+            return {"linked": 2, "communities": 1, "nodes": 5}
+        if "neighbors" in path:
+            return [{"id": 2, "rel": "similar_to", "weight": 0.9}]
+        if "import" in path:
+            return {"notes": 3, "links": 4}
+        return {"deleted": True, "id": 7}
+
+    c._call = fake_call
+    return c, calls
+
+
+def test_client_consolidate_posts():
+    c, calls = _spy_client()
+    out = c.consolidate(owner_id=1, tau=0.7, k=5)
+    assert out["communities"] == 1
+    method, path, body, owner = calls[0]
+    assert method == "POST"
+    assert path.endswith("/memory/consolidate")
+    assert body == {"tau": 0.7, "k": 5}
+
+
+def test_client_neighbors_gets():
+    c, calls = _spy_client()
+    out = c.neighbors(owner_id=1, node_id=7)
+    assert out[0]["rel"] == "similar_to"
+    method, path, _body, _o = calls[0]
+    assert method == "GET"
+    assert path.endswith("/memory/neighbors/7")
+
+
+def test_client_forget_deletes():
+    c, calls = _spy_client()
+    out = c.forget(owner_id=1, node_id=7)
+    assert out["deleted"] is True
+    method, path, _b, _o = calls[0]
+    assert method == "DELETE"
+    assert path.endswith("/memory/node/7")
+
+
+def test_client_import_obsidian_posts_path():
+    c, calls = _spy_client()
+    out = c.import_obsidian(owner_id=1, path="MyVault")
+    assert out["notes"] == 3
+    method, path, body, _o = calls[0]
+    assert method == "POST"
+    assert path.endswith("/memory/import/obsidian")
+    assert body == {"path": "MyVault"}
+
+
+# ── CLI verbs registered + wired to the client ────────────────────────────────
+
+
+@pytest.mark.parametrize("verb", ["mem.consolidate", "mem.neighbors", "mem.forget", "mem.import"])
+def test_verb_registered(verb):
+    assert verb in COMMAND_REGISTRY
+
+
+def _run_cli(verb: str, ns_extra: dict, fake):
+    """Invoke a mem command with a faked client factory; return exit code."""
+    import sndr.cli.commands.mem as m
+
+    orig = m._make_client
+    m._make_client = lambda args: fake
+    try:
+        base = {"url": None, "owner": None, "token": None}
+        base.update(ns_extra)
+        return COMMAND_REGISTRY[verb].execute(argparse.Namespace(**base))
+    finally:
+        m._make_client = orig
+
+
+class _Fake:
+    def __init__(self):
+        self.seen = []
+
+    def consolidate(self, **k):
+        self.seen.append(("consolidate", k))
+        return {"linked": 1, "communities": 1, "nodes": 3}
+
+    def neighbors(self, **k):
+        self.seen.append(("neighbors", k))
+        return [{"id": 2, "rel": "similar_to", "weight": 0.9}]
+
+    def forget(self, **k):
+        self.seen.append(("forget", k))
+        return {"deleted": True, "id": k.get("node_id")}
+
+    def import_obsidian(self, **k):
+        self.seen.append(("import_obsidian", k))
+        return {"notes": 3, "links": 4}
+
+
+def test_cli_consolidate_invokes_client():
+    f = _Fake()
+    rc = _run_cli("mem.consolidate", {"tau": 0.8, "k": 10}, f)
+    assert rc == 0
+    assert f.seen[0][0] == "consolidate"
+
+
+def test_cli_forget_invokes_client():
+    f = _Fake()
+    rc = _run_cli("mem.forget", {"node_id": 7}, f)
+    assert rc == 0
+    assert f.seen[0] == ("forget", {"owner_id": 1, "node_id": 7}) or f.seen[0][0] == "forget"
+
+
+def test_cli_import_invokes_client():
+    f = _Fake()
+    rc = _run_cli("mem.import", {"path": "Vault"}, f)
+    assert rc == 0
+    assert f.seen[0][0] == "import_obsidian"
+
+
+def test_cli_neighbors_invokes_client():
+    f = _Fake()
+    rc = _run_cli("mem.neighbors", {"node_id": 7}, f)
+    assert rc == 0
+    assert f.seen[0][0] == "neighbors"


### PR DESCRIPTION
## Why

Slice 2 of the memory-brain uplift — **surface coherence** (a HIGH gap from the 47-gap study: "the entire brain tier that the GUI+API expose is unreachable from the CLI"). The `sndr mem` surface was remember/recall/search/stats only, so an operator could not consolidate, inspect a node's connections, forget a memory, or import an Obsidian vault from the terminal — even though the GUI and API already did all of it.

> Stacked on #77 (typed-memory taxonomy).

## What

Four new verbs over the **existing** API routes — no engine/route changes:

```bash
sndr mem.consolidate   # POST /memory/consolidate — auto-link + communities + importance
sndr mem.neighbors 42  # GET  /memory/neighbors/{id}
sndr mem.forget 42     # DELETE /memory/node/{id}
sndr mem.import MyVault # POST /memory/import/obsidian
```

Additive: four thin `MemoryHTTPClient` methods + four CLI commands + registration.

## TDD

`tests/unit/test_memory_cli_verbs.py` (12 tests, red→green): each client method's `(verb, path, body)` is pinned against a spy, and each CLI command is asserted to invoke its client method with the right args. Registration parametrized over all four verbs.

## Verification
- 1014 passed / 122 skipped — full memory + CLI regression clean
- ruff-clean; audit_public_docs ✓ · security_scan ✓
- CLI_REFERENCE §7 updated (new verbs + the `--kind` memory types from slice 1)

## Remaining memory-brain roadmap (from the study)
reflection/insight synthesis (CREATE derived nodes) · working-memory tier · LLM fact-extraction + typed entity/relation KG · automated contradiction→invalidation · Obsidian bidirectional export + path identity + frontmatter · GUI/TUI coherence (`sndr switch`, memory brain features).