### PR TITLE
feat(memory): bidirectional Obsidian — export memory→vault + frontmatter-aware import

### DIFF
--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -752,18 +752,31 @@ python3 scripts/bump_pin.py 0.23.1rc1.devNNN+g<sha> \
 ## 7. Memory daemon (`mem.*`)
 
 Persistent memory (graph + vector) served by the running product-API
-daemon (`sndr up`, port 8765). All four verbs share `--url` (else
+daemon (`sndr up`, port 8765). Every verb shares `--url` (else
 `$SNDR_MEMORY_URL` / `$SNDR_GUI_URL`, default `http://127.0.0.1:8765`),
 `--owner` (else `$SNDR_MEMORY_OWNER`, default 1) and `--token` (else
 `$GENESIS_MEMORY_API_KEY`, sent as Bearer).
 
 ```bash
+# store / retrieve
 sndr mem.remember "the 27B rig uses TP=2"       # store a memory
+sndr mem.remember "Paris is the capital of France" --kind semantic   # typed (slow-decay) fact
 sndr mem.recall "27B rig"                       # graph expand + reinforce
 sndr mem.search "TP settings"                   # vector/hybrid search, no side effects
-sndr mem.stats                                  # node/edge counts for this owner
+sndr mem.stats                                  # node/edge/community counts
 sndr mem                                        # bare group → mem.stats
+
+# brain tier (was GUI/API-only before)
+sndr mem.consolidate                            # auto-link + detect communities + rank importance
+sndr mem.neighbors 42                           # graph connections of node 42
+sndr mem.forget 42                              # delete a memory + its edges
+sndr mem.import MyVault                          # import an Obsidian vault (notes+wikilinks)
 ```
+
+`--kind` selects the cognitive memory type — `working` (~30 min), `episodic`
+(~1 day), `semantic` (~1 week), `procedural` (~1 month) — which sets how fast
+the memory decays. `mem.import` reads a vault under the daemon's
+`GENESIS_MEMORY_VAULT_ROOT`.
 
 ---
 

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -771,6 +771,7 @@ sndr mem.consolidate                            # auto-link + detect communities
 sndr mem.neighbors 42                           # graph connections of node 42
 sndr mem.forget 42                              # delete a memory + its edges
 sndr mem.import MyVault                          # import an Obsidian vault (notes+wikilinks)
+sndr mem.export MyVaultOut                        # export memory back out as an Obsidian vault
 ```
 
 `--kind` selects the cognitive memory type — `working` (~30 min), `episodic`

--- a/sndr/cli/commands/__init__.py
+++ b/sndr/cli/commands/__init__.py
@@ -14,6 +14,7 @@ from sndr.cli.commands.kv_calc import KvCalcCommand
 from sndr.cli.commands.launch import LaunchCommand
 from sndr.cli.commands.mem import (
     MemConsolidateCommand,
+    MemExportCommand,
     MemForgetCommand,
     MemImportCommand,
     MemNeighborsCommand,
@@ -94,6 +95,7 @@ def build_subparsers(subparsers: argparse._SubParsersAction) -> None:
     register(MemNeighborsCommand())
     register(MemForgetCommand())
     register(MemImportCommand())
+    register(MemExportCommand())
     # TUI cockpit (read-only Phase 1) — the command gates on the optional [tui]
     # extra (textual) with a friendly install hint when it's absent.
     register(TuiCommand())

--- a/sndr/cli/commands/__init__.py
+++ b/sndr/cli/commands/__init__.py
@@ -13,6 +13,10 @@ from sndr.cli.commands.health import HealthCommand
 from sndr.cli.commands.kv_calc import KvCalcCommand
 from sndr.cli.commands.launch import LaunchCommand
 from sndr.cli.commands.mem import (
+    MemConsolidateCommand,
+    MemForgetCommand,
+    MemImportCommand,
+    MemNeighborsCommand,
     MemRecallCommand,
     MemRememberCommand,
     MemSearchCommand,
@@ -85,6 +89,11 @@ def build_subparsers(subparsers: argparse._SubParsersAction) -> None:
     register(MemRecallCommand())
     register(MemSearchCommand())
     register(MemStatsCommand())
+    # Brain-tier verbs — reachable from the terminal, not just GUI/API.
+    register(MemConsolidateCommand())
+    register(MemNeighborsCommand())
+    register(MemForgetCommand())
+    register(MemImportCommand())
     # TUI cockpit (read-only Phase 1) — the command gates on the optional [tui]
     # extra (textual) with a friendly install hint when it's absent.
     register(TuiCommand())

--- a/sndr/cli/commands/mem.py
+++ b/sndr/cli/commands/mem.py
@@ -173,7 +173,96 @@ class MemStatsCommand:
         return _run(args, _do)
 
 
+class MemConsolidateCommand:
+    name = "mem.consolidate"
+    help = "Run brain maintenance: semantic auto-link + communities + importance."
+
+    def configure_parser(self, parser: argparse.ArgumentParser) -> None:
+        parser.add_argument("--tau", type=float, default=0.8,
+                            help="semantic-link cosine threshold (default: 0.8)")
+        parser.add_argument("--k", type=int, default=10,
+                            help="kNN neighbours per node for linking (default: 10)")
+        _add_connection_args(parser)
+
+    def execute(self, args: argparse.Namespace) -> int:
+        def _do(client) -> int:
+            rep = client.consolidate(owner_id=_owner(args), tau=args.tau, k=args.k)
+            if getattr(args, "output", "text") == "json":
+                print(json.dumps(rep))
+            else:
+                print(f"consolidated: {rep.get('linked', 0)} links, "
+                      f"{rep.get('communities', 0)} communities over "
+                      f"{rep.get('nodes', 0)} nodes")
+            return 0
+        return _run(args, _do)
+
+
+class MemNeighborsCommand:
+    name = "mem.neighbors"
+    help = "List the nodes adjacent to a memory node (its graph connections)."
+
+    def configure_parser(self, parser: argparse.ArgumentParser) -> None:
+        parser.add_argument("node_id", type=int, help="node id to inspect")
+        _add_connection_args(parser)
+
+    def execute(self, args: argparse.Namespace) -> int:
+        def _do(client) -> int:
+            rows = client.neighbors(owner_id=_owner(args), node_id=args.node_id)
+            if getattr(args, "output", "text") == "json":
+                print(json.dumps(rows))
+            elif not rows:
+                print(f"node {args.node_id}: no neighbours")
+            else:
+                for r in rows:
+                    print(f"  {r.get('id')}  {r.get('rel'):<12} w={r.get('weight'):.3f}")
+            return 0
+        return _run(args, _do)
+
+
+class MemForgetCommand:
+    name = "mem.forget"
+    help = "Forget (delete) a memory node and its edges via the running daemon."
+
+    def configure_parser(self, parser: argparse.ArgumentParser) -> None:
+        parser.add_argument("node_id", type=int, help="node id to forget")
+        _add_connection_args(parser)
+
+    def execute(self, args: argparse.Namespace) -> int:
+        def _do(client) -> int:
+            out = client.forget(owner_id=_owner(args), node_id=args.node_id)
+            if getattr(args, "output", "text") == "json":
+                print(json.dumps(out))
+            else:
+                print(f"forgot node {out.get('id', args.node_id)}")
+            return 0
+        return _run(args, _do)
+
+
+class MemImportCommand:
+    name = "mem.import"
+    help = "Import an Obsidian vault (notes+wikilinks) into memory via the daemon."
+
+    def configure_parser(self, parser: argparse.ArgumentParser) -> None:
+        parser.add_argument("path", help="vault directory, relative to the daemon's "
+                                         "allowed vault root (GENESIS_MEMORY_VAULT_ROOT)")
+        _add_connection_args(parser)
+
+    def execute(self, args: argparse.Namespace) -> int:
+        def _do(client) -> int:
+            rep = client.import_obsidian(owner_id=_owner(args), path=args.path)
+            if getattr(args, "output", "text") == "json":
+                print(json.dumps(rep))
+            else:
+                print(f"imported: {rep.get('notes', 0)} notes, {rep.get('links', 0)} links")
+            return 0
+        return _run(args, _do)
+
+
 __all__ = [
+    "MemConsolidateCommand",
+    "MemForgetCommand",
+    "MemImportCommand",
+    "MemNeighborsCommand",
     "MemRecallCommand",
     "MemRememberCommand",
     "MemSearchCommand",

--- a/sndr/cli/commands/mem.py
+++ b/sndr/cli/commands/mem.py
@@ -258,8 +258,29 @@ class MemImportCommand:
         return _run(args, _do)
 
 
+class MemExportCommand:
+    name = "mem.export"
+    help = "Export memory back out as an Obsidian vault (notes + wikilinks)."
+
+    def configure_parser(self, parser: argparse.ArgumentParser) -> None:
+        parser.add_argument("path", help="target vault directory, relative to the "
+                                         "daemon's allowed vault root (GENESIS_MEMORY_VAULT_ROOT)")
+        _add_connection_args(parser)
+
+    def execute(self, args: argparse.Namespace) -> int:
+        def _do(client) -> int:
+            rep = client.export_obsidian(owner_id=_owner(args), path=args.path)
+            if getattr(args, "output", "text") == "json":
+                print(json.dumps(rep))
+            else:
+                print(f"exported: {rep.get('notes', 0)} notes, {rep.get('links', 0)} links")
+            return 0
+        return _run(args, _do)
+
+
 __all__ = [
     "MemConsolidateCommand",
+    "MemExportCommand",
     "MemForgetCommand",
     "MemImportCommand",
     "MemNeighborsCommand",

--- a/sndr/cli/commands/mem.py
+++ b/sndr/cli/commands/mem.py
@@ -89,7 +89,12 @@ class MemRememberCommand:
 
     def configure_parser(self, parser: argparse.ArgumentParser) -> None:
         parser.add_argument("text", help="the text to remember")
-        parser.add_argument("--kind", default="note", help="node kind (default: note)")
+        parser.add_argument(
+            "--kind", default="note",
+            help="memory type — working (fades in ~30 min), episodic (~1 day), "
+                 "semantic (~1 week), procedural (~1 month); drives how fast it "
+                 "decays. Any other value keeps the neutral 1-day rate (default: note).",
+        )
         parser.add_argument("--importance", type=float, default=0.0,
                             help="seed importance in [0,1] (default: 0.0)")
         _add_connection_args(parser)

--- a/sndr/memory/client.py
+++ b/sndr/memory/client.py
@@ -110,3 +110,32 @@ class MemoryHTTPClient:
     def stats(self, *, owner_id: int) -> dict[str, int]:
         """Owner memory counts: ``{"nodes": int, "edges": int}``."""
         return self._call("GET", "/api/v1/memory/stats", owner=owner_id)
+
+    # ── brain-tier verbs (were GUI/API-only before) ──────────────────────────
+    def consolidate(
+        self, *, owner_id: int, tau: float = 0.8, k: int = 10
+    ) -> dict[str, int]:
+        """Run the batch brain maintenance: semantic auto-link + community
+        detection + importance recompute. Returns ``{linked, communities, nodes}``."""
+        return self._call(
+            "POST", "/api/v1/memory/consolidate", {"tau": tau, "k": k}, owner=owner_id
+        )
+
+    def neighbors(self, *, owner_id: int, node_id: int) -> list[dict[str, Any]]:
+        """Adjacent nodes of ``node_id``: ``[{id, rel, weight}, ...]``."""
+        return self._call(
+            "GET", f"/api/v1/memory/neighbors/{node_id}", owner=owner_id
+        )
+
+    def forget(self, *, owner_id: int, node_id: int) -> dict[str, Any]:
+        """Delete a memory node (and its edges). Returns ``{deleted, id}``."""
+        return self._call(
+            "DELETE", f"/api/v1/memory/node/{node_id}", owner=owner_id
+        )
+
+    def import_obsidian(self, *, owner_id: int, path: str) -> dict[str, int]:
+        """Import an Obsidian vault (relative to the daemon's allowed root) into
+        memory: notes -> nodes, [[wikilinks]] -> edges. Returns ``{notes, links}``."""
+        return self._call(
+            "POST", "/api/v1/memory/import/obsidian", {"path": path}, owner=owner_id
+        )

--- a/sndr/memory/client.py
+++ b/sndr/memory/client.py
@@ -139,3 +139,10 @@ class MemoryHTTPClient:
         return self._call(
             "POST", "/api/v1/memory/import/obsidian", {"path": path}, owner=owner_id
         )
+
+    def export_obsidian(self, *, owner_id: int, path: str) -> dict[str, int]:
+        """Export memory back OUT as an Obsidian vault (one note per node, edges
+        as [[wikilinks]]) under the daemon's allowed root. Returns ``{notes, links}``."""
+        return self._call(
+            "POST", "/api/v1/memory/export/obsidian", {"path": path}, owner=owner_id
+        )

--- a/sndr/memory/model.py
+++ b/sndr/memory/model.py
@@ -21,6 +21,40 @@ HEBBIAN_LAMBDA: float = 0.995  # retention (1 - decay) per co-access step
 # S is the base memory-strength time-constant in seconds; importance scales it.
 EBBINGHAUS_S: float = 86_400.0  # 1 day base half-life scale
 
+# ── Cognitive memory taxonomy (working / episodic / semantic / procedural).
+# The brain forgets different kinds of memory at very different rates: a
+# working-memory scratchpad fades in minutes, an episode over a day or two, a
+# learned fact over weeks, a skill barely at all. Each type scales the base
+# Ebbinghaus time-constant `S` by its factor (applied once in store._retention,
+# so both backends stay identical). ANY other/legacy kind ("note",
+# "conversation", …) maps to 1.0 — exactly the pre-taxonomy behaviour, so
+# nothing already stored changes.
+MEMORY_TYPES: tuple[str, ...] = ("working", "episodic", "semantic", "procedural")
+DEFAULT_MEMORY_TYPE: str = "episodic"  # a captured experience is episodic by default
+
+TYPE_DECAY_FACTOR: dict[str, float] = {
+    "working": 0.02,      # ~30 min half-life — the current-context scratchpad
+    "episodic": 1.0,      # ~1 day — an experience/event (the historical baseline)
+    "semantic": 8.0,      # ~1 week — a consolidated fact/concept
+    "procedural": 30.0,   # ~1 month — a learned skill / how-to (persists longest)
+}
+
+
+def type_decay_factor(kind: str) -> float:
+    """Ebbinghaus time-constant multiplier for a memory kind. Unknown/legacy
+    kinds return 1.0 (neutral — the pre-taxonomy behaviour)."""
+    return TYPE_DECAY_FACTOR.get(kind, 1.0)
+
+
+def normalize_memory_type(value: str | None) -> str:
+    """Coerce a user-supplied type to a canonical one, defaulting to episodic.
+    Never raises — a bad value degrades to the default rather than blocking a
+    write."""
+    if not value:
+        return DEFAULT_MEMORY_TYPE
+    v = str(value).strip().lower()
+    return v if v in MEMORY_TYPES else DEFAULT_MEMORY_TYPE
+
 # ── Spreading activation along the graph during expand (design section 3).
 SPREAD_DAMPING: float = 0.5   # beta: score multiplier per hop
 MAX_EXPAND_DEPTH: int = 3     # bounded traversal (cycle-safe)

--- a/sndr/memory/obsidian.py
+++ b/sndr/memory/obsidian.py
@@ -24,6 +24,8 @@ if TYPE_CHECKING:
 _WIKILINK_RE = re.compile(r"\[\[([^\]]+)\]\]")
 _TAG_RE = re.compile(r"(?:^|\s)#(\w[\w/-]*)")
 _H1_RE = re.compile(r"^#\s+(.+?)\s*$", re.M)  # the note's display title (first H1)
+_FRONTMATTER_RE = re.compile(r"\A---\r?\n(.*?)\r?\n---\r?\n", re.S)
+_UNSAFE_FILENAME_RE = re.compile(r'[<>:"/\\|?*\x00-\x1f]')
 
 
 def _wikilink_target(raw: str) -> str:
@@ -31,6 +33,48 @@ def _wikilink_target(raw: str) -> str:
     target = raw.split("|", 1)[0]
     target = target.split("#", 1)[0]
     return target.strip()
+
+
+def _parse_frontmatter(text: str) -> tuple[dict[str, list[str]], str]:
+    """Split a leading Obsidian `---` YAML frontmatter block off `text`.
+
+    Returns ({key: [values]}, body). Dependency-free: handles the two common
+    list forms — inline ``tags: [a, b]`` and block ``tags:`` + ``  - a`` — for
+    the keys we care about (tags, aliases). Anything unparseable is ignored,
+    never raised.
+    """
+    m = _FRONTMATTER_RE.match(text)
+    if not m:
+        return {}, text
+    block, body = m.group(1), text[m.end():]
+    fields: dict[str, list[str]] = {}
+    current: str | None = None
+    for raw in block.splitlines():
+        if not raw.strip():
+            continue
+        if raw[:1].isspace():  # block-list continuation ("  - value")
+            item = raw.strip().lstrip("-").strip().strip("'\"")
+            if current and item:
+                fields.setdefault(current, []).append(item)
+            continue
+        if ":" not in raw:
+            continue
+        key, _, val = raw.partition(":")
+        current = key.strip().lower()
+        val = val.strip()
+        if not val:
+            continue  # values arrive on following block-list lines
+        if val.startswith("[") and val.endswith("]"):
+            items = [v.strip().strip("'\"") for v in val[1:-1].split(",")]
+            fields[current] = [v for v in items if v]
+        else:
+            fields[current] = [val.strip("'\"")]
+    return fields, body
+
+
+def _safe_filename(name: str, node_id: int) -> str:
+    stem = _UNSAFE_FILENAME_RE.sub("-", name).strip() or f"node-{node_id}"
+    return f"{stem}.md"
 
 
 def import_vault(
@@ -66,21 +110,30 @@ def import_vault(
         except (OSError, UnicodeDecodeError):
             continue
         title = path.stem
-        tags = sorted(set(_TAG_RE.findall(text)))
+        frontmatter, _body = _parse_frontmatter(text)
+        # Tags = inline #tags UNION frontmatter `tags:`. Aliases from frontmatter
+        # become extra resolution keys for wikilinks (Obsidian resolves [[alias]]).
+        aliases = frontmatter.get("aliases", [])
+        rel_path = str(real.relative_to(root_real))
+        tags = sorted(set(_TAG_RE.findall(text)) | set(frontmatter.get("tags", [])))
         node_id = engine.remember(
             owner_id=owner_id,
             text=text,
             kind=kind,
-            properties={"title": title, "source": "obsidian", "tags": tags},
+            properties={
+                "title": title, "source": "obsidian", "tags": tags,
+                "path": rel_path, "aliases": aliases,
+            },
             dedup=True,
         )
-        # Index by BOTH the filename stem AND the first H1, case-INSENSITIVELY —
-        # Obsidian resolves [[Note]] to either, ignoring case, so a link like
-        # [[Qwen3.6-35B]] finds qwen.md whose H1 is "# Qwen3.6-35B".
+        # Index by the filename stem, the first H1, AND every frontmatter alias,
+        # case-INSENSITIVELY — Obsidian resolves [[Note]] to any of them.
         title_to_id[title.lower()] = node_id
         h1 = _H1_RE.search(text)
         if h1:
             title_to_id.setdefault(h1.group(1).strip().lower(), node_id)
+        for alias in aliases:
+            title_to_id.setdefault(alias.strip().lower(), node_id)
         wikilinks[node_id] = [_wikilink_target(m) for m in _WIKILINK_RE.findall(text)]
         notes += 1
 
@@ -99,3 +152,61 @@ def import_vault(
             links += 1
 
     return {"notes": notes, "links": links, "missing": missing}
+
+
+def _node_title(node) -> str:
+    """Display title for a node: its stored `title`, else the first H1, else a
+    stable node-id fallback."""
+    title = node.properties.get("title")
+    if title:
+        return str(title)
+    h1 = _H1_RE.search(node.content or "")
+    return h1.group(1).strip() if h1 else f"node-{node.id}"
+
+
+def export_vault(
+    *, engine: MemoryEngine, owner_id: int, vault_path: str
+) -> dict[str, int]:
+    """Materialize this owner's memory graph OUT as an Obsidian vault: one `.md`
+    note per node (its content), with outgoing non-invalidated edges rendered as
+    a `## Links` section of `[[wikilinks]]` to the neighbour nodes' titles.
+
+    The inverse of :func:`import_vault` — so agent-generated memories become notes
+    you can open in Obsidian. Returns {notes, links}. Path safety (confining the
+    vault to an allowed root) is the caller's job; this needs a real directory.
+    """
+    root = Path(vault_path)
+    root.mkdir(parents=True, exist_ok=True)
+    root_real = root.resolve()
+
+    nodes = list(engine.store.iter_nodes(owner_id))
+    id_to_title = {n.id: _node_title(n) for n in nodes}
+
+    used: set[str] = set()
+    notes = 0
+    links = 0
+    for node in nodes:
+        title = id_to_title[node.id]
+        fname = _safe_filename(title, node.id)
+        if fname in used:  # title collision -> disambiguate by id
+            fname = _safe_filename(f"{title}-{node.id}", node.id)
+        used.add(fname)
+
+        body = (node.content or "").rstrip()
+        wikilinks = []
+        for dst_id, _rel, _w in engine.store.neighbors(node.id):
+            dst_title = id_to_title.get(dst_id)
+            if dst_title:
+                wikilinks.append(f"- [[{dst_title}]]")
+                links += 1
+        parts = [body]
+        if wikilinks:
+            parts.append("\n## Links\n" + "\n".join(wikilinks))
+        out_path = (root_real / fname)
+        # Defense in depth: never write outside the vault root.
+        if out_path.resolve().parent != root_real:
+            continue
+        out_path.write_text("\n".join(parts) + "\n", encoding="utf-8")
+        notes += 1
+
+    return {"notes": notes, "links": links}

--- a/sndr/memory/store.py
+++ b/sndr/memory/store.py
@@ -22,7 +22,12 @@ import time
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any
 
-from sndr.memory.model import EBBINGHAUS_S, SPREAD_DAMPING, SearchHit
+from sndr.memory.model import (
+    EBBINGHAUS_S,
+    SPREAD_DAMPING,
+    SearchHit,
+    type_decay_factor,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Iterator, Sequence
@@ -127,14 +132,23 @@ class MemoryStore(ABC):
         """
 
     def _retention(self, node: MemoryNode, now: float) -> float:
-        """Ebbinghaus retention R = exp(-age / (S * strength * (1 + importance))).
+        """Ebbinghaus retention
+        R = exp(-age / (S * type_factor * strength * (1 + importance))).
 
-        `strength` is the reinforcement base (grows with retrieval, see _touch),
-        so frequently-recalled memories decay slower — the spacing effect.
+        `type_factor` is the cognitive-taxonomy multiplier (working forgets fast,
+        procedural slow; unknown/legacy kinds = 1.0, so decay is unchanged for
+        anything already stored). `strength` is the reinforcement base (grows
+        with retrieval, see _touch), so frequently-recalled memories decay
+        slower — the spacing effect.
         """
         age = max(0.0, now - node.accessed_at)
         strength = node.strength if node.strength and node.strength > 0 else 1.0
-        scale = EBBINGHAUS_S * strength * (1.0 + max(0.0, node.importance))
+        scale = (
+            EBBINGHAUS_S
+            * type_decay_factor(node.kind)
+            * strength
+            * (1.0 + max(0.0, node.importance))
+        )
         return math.exp(-age / scale)
 
     def recall(

--- a/sndr/product_api/routes/memory.py
+++ b/sndr/product_api/routes/memory.py
@@ -39,6 +39,8 @@ from sndr.product_api.schemas.memory import (
     LinkOut,
     NeighborOut,
     NodeOut,
+    ObsidianExportIn,
+    ObsidianExportOut,
     ObsidianImportIn,
     ObsidianImportOut,
     RecallIn,
@@ -245,6 +247,18 @@ def import_obsidian(
         raise HTTPException(status_code=404, detail="vault not found")
     report = import_vault(engine=eng, owner_id=owner_from_request(request), vault_path=str(vault))
     return Envelope(data=ObsidianImportOut(**report), meta=_meta())
+
+
+@router.post("/export/obsidian", summary="Export memory back out as an Obsidian vault")
+def export_obsidian(
+    body: ObsidianExportIn, request: Request
+) -> Envelope[ObsidianExportOut]:
+    from sndr.memory.obsidian import export_vault
+
+    eng = _engine(request)
+    vault = _confined_vault(body.path)  # export creates the dir; no is_dir gate
+    report = export_vault(engine=eng, owner_id=owner_from_request(request), vault_path=str(vault))
+    return Envelope(data=ObsidianExportOut(**report), meta=_meta())
 
 
 __all__ = ["router"]

--- a/sndr/product_api/schemas/memory.py
+++ b/sndr/product_api/schemas/memory.py
@@ -9,7 +9,12 @@ from pydantic import BaseModel, Field
 
 class RememberIn(BaseModel):
     text: str = Field(min_length=1)
-    kind: str = "note"
+    kind: str = Field(
+        default="note",
+        description="Memory type driving decay rate: working (~30 min), "
+        "episodic (~1 day), semantic (~1 week), procedural (~1 month). "
+        "Any other value keeps the neutral 1-day rate.",
+    )
     importance: float = 0.0
     properties: dict[str, Any] = Field(default_factory=dict)
 

--- a/sndr/product_api/schemas/memory.py
+++ b/sndr/product_api/schemas/memory.py
@@ -65,6 +65,15 @@ class ObsidianImportOut(BaseModel):
     missing: int
 
 
+class ObsidianExportIn(BaseModel):
+    path: str = Field(min_length=1, description="target vault dir, relative to the allowed root")
+
+
+class ObsidianExportOut(BaseModel):
+    notes: int
+    links: int
+
+
 class HitOut(BaseModel):
     id: int
     content: str

--- a/tests/unit/test_memory_cli_verbs.py
+++ b/tests/unit/test_memory_cli_verbs.py
@@ -41,6 +41,8 @@ def _spy_client():
             return {"linked": 2, "communities": 1, "nodes": 5}
         if "neighbors" in path:
             return [{"id": 2, "rel": "similar_to", "weight": 0.9}]
+        if "export" in path:
+            return {"notes": 5, "links": 6}
         if "import" in path:
             return {"notes": 3, "links": 4}
         return {"deleted": True, "id": 7}
@@ -87,10 +89,20 @@ def test_client_import_obsidian_posts_path():
     assert body == {"path": "MyVault"}
 
 
+def test_client_export_obsidian_posts_path():
+    c, calls = _spy_client()
+    out = c.export_obsidian(owner_id=1, path="OutVault")
+    assert out["notes"] == 5
+    method, path, body, _o = calls[0]
+    assert method == "POST"
+    assert path.endswith("/memory/export/obsidian")
+    assert body == {"path": "OutVault"}
+
+
 # ── CLI verbs registered + wired to the client ────────────────────────────────
 
 
-@pytest.mark.parametrize("verb", ["mem.consolidate", "mem.neighbors", "mem.forget", "mem.import"])
+@pytest.mark.parametrize("verb", ["mem.consolidate", "mem.neighbors", "mem.forget", "mem.import", "mem.export"])
 def test_verb_registered(verb):
     assert verb in COMMAND_REGISTRY
 
@@ -129,6 +141,10 @@ class _Fake:
         self.seen.append(("import_obsidian", k))
         return {"notes": 3, "links": 4}
 
+    def export_obsidian(self, **k):
+        self.seen.append(("export_obsidian", k))
+        return {"notes": 5, "links": 6}
+
 
 def test_cli_consolidate_invokes_client():
     f = _Fake()
@@ -156,3 +172,10 @@ def test_cli_neighbors_invokes_client():
     rc = _run_cli("mem.neighbors", {"node_id": 7}, f)
     assert rc == 0
     assert f.seen[0][0] == "neighbors"
+
+
+def test_cli_export_invokes_client():
+    f = _Fake()
+    rc = _run_cli("mem.export", {"path": "OutVault"}, f)
+    assert rc == 0
+    assert f.seen[0][0] == "export_obsidian"

--- a/tests/unit/test_memory_cli_verbs.py
+++ b/tests/unit/test_memory_cli_verbs.py
@@ -1,0 +1,158 @@
+# SPDX-License-Identifier: Apache-2.0
+"""CLI/client coherence: the brain-tier memory verbs must be reachable from the
+terminal, not just the GUI/API.
+
+Before this the `sndr mem` surface was remember/recall/search/stats only — an
+operator could not consolidate, inspect a node's neighbours, forget a memory, or
+import an Obsidian vault without hand-rolling HTTP. These four verbs close that
+gap over the EXISTING API routes (POST /consolidate, GET /neighbors/{id},
+DELETE /node/{id}, POST /import/obsidian).
+"""
+from __future__ import annotations
+
+import argparse
+
+import pytest
+
+pytest.importorskip("pydantic")
+
+from sndr.cli.commands import COMMAND_REGISTRY  # noqa: E402
+from sndr.memory.client import MemoryHTTPClient  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _registry():
+    from sndr.cli.main import build_parser
+
+    build_parser()
+
+
+# ── client methods construct the right (method, path, body) ───────────────────
+
+
+def _spy_client():
+    calls = []
+    c = MemoryHTTPClient("http://x", owner_id=1)
+
+    def fake_call(method, path, body=None, owner=None):
+        calls.append((method, path, body, owner))
+        # Return shapes the methods expect.
+        if "consolidate" in path:
+            return {"linked": 2, "communities": 1, "nodes": 5}
+        if "neighbors" in path:
+            return [{"id": 2, "rel": "similar_to", "weight": 0.9}]
+        if "import" in path:
+            return {"notes": 3, "links": 4}
+        return {"deleted": True, "id": 7}
+
+    c._call = fake_call
+    return c, calls
+
+
+def test_client_consolidate_posts():
+    c, calls = _spy_client()
+    out = c.consolidate(owner_id=1, tau=0.7, k=5)
+    assert out["communities"] == 1
+    method, path, body, owner = calls[0]
+    assert method == "POST"
+    assert path.endswith("/memory/consolidate")
+    assert body == {"tau": 0.7, "k": 5}
+
+
+def test_client_neighbors_gets():
+    c, calls = _spy_client()
+    out = c.neighbors(owner_id=1, node_id=7)
+    assert out[0]["rel"] == "similar_to"
+    method, path, _body, _o = calls[0]
+    assert method == "GET"
+    assert path.endswith("/memory/neighbors/7")
+
+
+def test_client_forget_deletes():
+    c, calls = _spy_client()
+    out = c.forget(owner_id=1, node_id=7)
+    assert out["deleted"] is True
+    method, path, _b, _o = calls[0]
+    assert method == "DELETE"
+    assert path.endswith("/memory/node/7")
+
+
+def test_client_import_obsidian_posts_path():
+    c, calls = _spy_client()
+    out = c.import_obsidian(owner_id=1, path="MyVault")
+    assert out["notes"] == 3
+    method, path, body, _o = calls[0]
+    assert method == "POST"
+    assert path.endswith("/memory/import/obsidian")
+    assert body == {"path": "MyVault"}
+
+
+# ── CLI verbs registered + wired to the client ────────────────────────────────
+
+
+@pytest.mark.parametrize("verb", ["mem.consolidate", "mem.neighbors", "mem.forget", "mem.import"])
+def test_verb_registered(verb):
+    assert verb in COMMAND_REGISTRY
+
+
+def _run_cli(verb: str, ns_extra: dict, fake):
+    """Invoke a mem command with a faked client factory; return exit code."""
+    import sndr.cli.commands.mem as m
+
+    orig = m._make_client
+    m._make_client = lambda args: fake
+    try:
+        base = {"url": None, "owner": None, "token": None}
+        base.update(ns_extra)
+        return COMMAND_REGISTRY[verb].execute(argparse.Namespace(**base))
+    finally:
+        m._make_client = orig
+
+
+class _Fake:
+    def __init__(self):
+        self.seen = []
+
+    def consolidate(self, **k):
+        self.seen.append(("consolidate", k))
+        return {"linked": 1, "communities": 1, "nodes": 3}
+
+    def neighbors(self, **k):
+        self.seen.append(("neighbors", k))
+        return [{"id": 2, "rel": "similar_to", "weight": 0.9}]
+
+    def forget(self, **k):
+        self.seen.append(("forget", k))
+        return {"deleted": True, "id": k.get("node_id")}
+
+    def import_obsidian(self, **k):
+        self.seen.append(("import_obsidian", k))
+        return {"notes": 3, "links": 4}
+
+
+def test_cli_consolidate_invokes_client():
+    f = _Fake()
+    rc = _run_cli("mem.consolidate", {"tau": 0.8, "k": 10}, f)
+    assert rc == 0
+    assert f.seen[0][0] == "consolidate"
+
+
+def test_cli_forget_invokes_client():
+    f = _Fake()
+    rc = _run_cli("mem.forget", {"node_id": 7}, f)
+    assert rc == 0
+    assert f.seen[0] == ("forget", {"owner_id": 1, "node_id": 7}) or f.seen[0][0] == "forget"
+
+
+def test_cli_import_invokes_client():
+    f = _Fake()
+    rc = _run_cli("mem.import", {"path": "Vault"}, f)
+    assert rc == 0
+    assert f.seen[0][0] == "import_obsidian"
+
+
+def test_cli_neighbors_invokes_client():
+    f = _Fake()
+    rc = _run_cli("mem.neighbors", {"node_id": 7}, f)
+    assert rc == 0
+    assert f.seen[0][0] == "neighbors"

--- a/tests/unit/test_memory_obsidian_bidir.py
+++ b/tests/unit/test_memory_obsidian_bidir.py
@@ -1,0 +1,102 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Obsidian integration, both directions.
+
+Before this the vault link was import-only, and the importer ignored YAML
+frontmatter (tags/aliases/title). This adds:
+  * `export_vault` — materialize the memory graph back OUT as Obsidian markdown
+    (one note per node, edges rendered as [[wikilinks]]), so agent-generated
+    memories show up in your vault.
+  * frontmatter-aware import — parse the `---` block for tags + aliases, and
+    resolve wikilinks that target an alias.
+"""
+from __future__ import annotations
+
+from sndr.memory.embedder import HashEmbedder
+from sndr.memory.engine import MemoryEngine
+from sndr.memory.inmemory import InMemoryStore
+from sndr.memory.obsidian import export_vault, import_vault
+
+
+def _engine() -> MemoryEngine:
+    return MemoryEngine(store=InMemoryStore(), embedder=HashEmbedder(dim=64))
+
+
+# ── export: memory -> vault ───────────────────────────────────────────────────
+
+
+def test_export_writes_one_markdown_file_per_node(tmp_path):
+    eng = _engine()
+    eng.remember(owner_id=1, text="Qwen3.6-35B runs at TP=2",
+                 properties={"title": "Qwen Rig"})
+    eng.remember(owner_id=1, text="Gemma 4 26B fits one card",
+                 properties={"title": "Gemma Rig"})
+    rep = export_vault(engine=eng, owner_id=1, vault_path=str(tmp_path))
+    md = sorted(p.name for p in tmp_path.rglob("*.md"))
+    assert len(md) == 2
+    assert rep["notes"] == 2
+    # Content is materialized.
+    joined = "\n".join(p.read_text() for p in tmp_path.rglob("*.md"))
+    assert "TP=2" in joined
+
+
+def test_export_renders_edges_as_wikilinks(tmp_path):
+    eng = _engine()
+    a = eng.remember(owner_id=1, text="note A", properties={"title": "Alpha"})
+    b = eng.remember(owner_id=1, text="note B", properties={"title": "Beta"})
+    eng.store.add_edge(a, b, "wikilink", weight=1.0)
+    export_vault(engine=eng, owner_id=1, vault_path=str(tmp_path))
+    joined = "\n".join(p.read_text() for p in tmp_path.rglob("*.md"))
+    assert "[[Beta]]" in joined
+
+
+def test_export_only_touches_own_owner(tmp_path):
+    eng = _engine()
+    eng.remember(owner_id=1, text="mine", properties={"title": "Mine"})
+    eng.remember(owner_id=2, text="theirs", properties={"title": "Theirs"})
+    rep = export_vault(engine=eng, owner_id=1, vault_path=str(tmp_path))
+    assert rep["notes"] == 1
+
+
+def test_import_then_export_round_trips(tmp_path):
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    (vault / "A.md").write_text("# A\nlinks to [[B]]\n")
+    (vault / "B.md").write_text("# B\nleaf\n")
+    eng = _engine()
+    import_vault(engine=eng, owner_id=1, vault_path=str(vault))
+    out = tmp_path / "out"
+    out.mkdir()
+    rep = export_vault(engine=eng, owner_id=1, vault_path=str(out))
+    assert rep["notes"] == 2
+    # The [[B]] edge survives the round-trip into the exported markdown.
+    joined = "\n".join(p.read_text() for p in out.rglob("*.md"))
+    assert "[[B]]" in joined
+
+
+# ── frontmatter-aware import ──────────────────────────────────────────────────
+
+
+def test_import_parses_frontmatter_tags(tmp_path):
+    vault = tmp_path
+    (vault / "Note.md").write_text(
+        "---\ntags: [rig, gpu]\naliases: [TheRig]\n---\n# Note\nbody\n"
+    )
+    eng = _engine()
+    import_vault(engine=eng, owner_id=1, vault_path=str(vault))
+    node = next(eng.store.iter_nodes(1))
+    tags = node.properties.get("tags", [])
+    assert "rig" in tags
+    assert "gpu" in tags
+
+
+def test_import_resolves_wikilink_to_frontmatter_alias(tmp_path):
+    vault = tmp_path
+    (vault / "Canonical.md").write_text(
+        "---\naliases: [Nick]\n---\n# Canonical\nthe real note\n"
+    )
+    (vault / "Other.md").write_text("# Other\nsee [[Nick]]\n")
+    eng = _engine()
+    rep = import_vault(engine=eng, owner_id=1, vault_path=str(vault))
+    # The [[Nick]] link resolves to the aliased note -> a real edge, not missing.
+    assert rep["links"] >= 1
+    assert rep["missing"] == 0

--- a/tests/unit/test_memory_types.py
+++ b/tests/unit/test_memory_types.py
@@ -1,0 +1,97 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Typed memory taxonomy — the cognitive working / episodic / semantic /
+procedural distinction, and its effect on the Ebbinghaus decay time-constant.
+
+The brain does not forget all memories at the same rate: a working-memory
+scratchpad fades in minutes, an episode over days, a learned fact over weeks, a
+skill barely at all. Before this, every node decayed on the same 1-day base
+constant regardless of what kind of memory it was. This gives each memory TYPE
+its own decay multiplier, applied at the single shared `_retention` seam so both
+backends stay numerically identical.
+
+Regression safety: any *unknown* kind (the historical "note"/"conversation"
+values, and the contract-test default "note") maps to factor 1.0 — i.e. exactly
+the previous behaviour — so nothing already stored changes.
+"""
+from __future__ import annotations
+
+import math
+
+from sndr.memory import model
+
+
+def test_canonical_memory_types_defined():
+    assert model.MEMORY_TYPES == ("working", "episodic", "semantic", "procedural")
+
+
+def test_type_decay_factor_ordering():
+    """working forgets fastest, procedural slowest — a strict ladder."""
+    f = model.type_decay_factor
+    assert f("working") < f("episodic") < f("semantic") < f("procedural")
+
+
+def test_working_memory_is_short_lived():
+    """Working memory's factor is well under a day (fast-expiring scratchpad)."""
+    assert model.type_decay_factor("working") < 0.1
+
+
+def test_unknown_kind_is_neutral_factor_one():
+    """No regression: legacy/unknown kinds decay exactly as before (factor 1.0)."""
+    assert model.type_decay_factor("note") == 1.0
+    assert model.type_decay_factor("conversation") == 1.0
+    assert model.type_decay_factor("") == 1.0
+    assert model.type_decay_factor("something-new") == 1.0
+
+
+def test_normalize_type_accepts_canonical_and_defaults():
+    assert model.normalize_memory_type("semantic") == "semantic"
+    assert model.normalize_memory_type("SEMANTIC") == "semantic"
+    # An unrecognized value falls back to the episodic default, never crashes.
+    assert model.normalize_memory_type("nonsense") == "episodic"
+    assert model.normalize_memory_type(None) == "episodic"
+
+
+# ── decay behaviour through the real store seam ───────────────────────────────
+
+
+def _node(kind: str) -> model.MemoryNode:
+    return model.MemoryNode(
+        id=1, owner_id=1, kind=kind, content="x",
+        strength=1.0, importance=0.0, accessed_at=0.0,
+    )
+
+
+def _retention(store, node, now):
+    return store._retention(node, now)
+
+
+def test_working_decays_faster_than_semantic_at_same_age():
+    from sndr.memory.inmemory import InMemoryStore
+
+    store = InMemoryStore()
+    age = model.EBBINGHAUS_S  # one base time-constant of elapsed time
+    r_working = _retention(store, _node("working"), age)
+    r_semantic = _retention(store, _node("semantic"), age)
+    assert r_working < r_semantic
+
+
+def test_note_retention_unchanged_vs_manual_formula():
+    """The historical 'note' path must still equal the bare Ebbinghaus formula."""
+    from sndr.memory.inmemory import InMemoryStore
+
+    store = InMemoryStore()
+    age = 3600.0
+    expected = math.exp(-age / (model.EBBINGHAUS_S * 1.0 * 1.0))  # strength=1, imp=0
+    assert abs(_retention(store, _node("note"), age) - expected) < 1e-9
+
+
+def test_remember_accepts_and_stores_memory_type():
+    from sndr.memory.embedder import HashEmbedder
+    from sndr.memory.engine import MemoryEngine
+    from sndr.memory.inmemory import InMemoryStore
+
+    eng = MemoryEngine(store=InMemoryStore(), embedder=HashEmbedder(dim=64))
+    nid = eng.remember(owner_id=1, text="Paris is the capital of France",
+                       kind="semantic")
+    node = eng.store.get_node(nid)
+    assert node.kind == "semantic"


### PR DESCRIPTION
## Why

Slice 3 of the memory-brain uplift — **Obsidian×AI** (your explicit request: "how others integrate Obsidian with AI, internal and external"). The 47-gap study flagged the vault link as HIGH-severity import-only, with content-only dedup and no frontmatter parsing. This makes it two-way.

> Stacked on #78 → #77.

## What

- **`export_vault` (memory → vault):** materialize the graph OUT as an Obsidian vault — one `.md` per node (its content), each outgoing non-invalidated edge as a `## Links` `[[wikilink]]` to the neighbour's title. So agent-generated memories become notes you open in Obsidian. Owner-scoped, filename-collision-safe, write-confined to the vault root.
- **Frontmatter-aware import:** parse the leading `---` block (dependency-free — both `tags: [a, b]` and block-list forms) for `tags:` (unioned with inline `#tags`) and `aliases:` (registered as extra `[[wikilink]]` resolution keys + stored on the node). Each note now records its vault-relative `path`.
- **Reachable end-to-end:** `POST /api/v1/memory/export/obsidian` + `MemoryHTTPClient.export_obsidian` + `sndr mem.export <vault>` (CLI_REFERENCE §7).

## TDD

`tests/unit/test_memory_obsidian_bidir.py` (6): export writes a file per node, renders edges as `[[wikilinks]]`, is owner-scoped, **round-trips** import→export, parses frontmatter tags, resolves a wikilink to a frontmatter alias. Plus export client-method + `sndr mem.export` verb tests.

## Verification
- full memory + obsidian + API + CLI regression green; ruff-clean; audit_public_docs ✓ · security_scan ✓

## Deferred (tracked)
Path-keyed dedup (update-in-place on re-import, instead of a new node on edit) needs a store `find-by-property`/`update` primitive — next slice. Then: reflection/insight synthesis, working-memory tier, LLM fact-extraction + typed KG, GUI/TUI coherence.