### PR TITLE
feat(memory): generative reflection — synthesize insight nodes from clusters (Generative-Agents)

### DIFF
--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -768,11 +768,16 @@ sndr mem                                        # bare group → mem.stats
 
 # brain tier (was GUI/API-only before)
 sndr mem.consolidate                            # auto-link + detect communities + rank importance
+sndr mem.reflect                                # generative: synthesize insight nodes from clusters
 sndr mem.neighbors 42                           # graph connections of node 42
 sndr mem.forget 42                              # delete a memory + its edges
 sndr mem.import MyVault                          # import an Obsidian vault (notes+wikilinks)
 sndr mem.export MyVaultOut                        # export memory back out as an Obsidian vault
 ```
+
+`mem.reflect` clusters related memories and has the running engine synthesize a
+higher-level insight per cluster, stored as a new `semantic` node linked to its
+sources (needs `SNDR_OPENAI_BASE_URL` pointed at the engine).
 
 `--kind` selects the cognitive memory type — `working` (~30 min), `episodic`
 (~1 day), `semantic` (~1 week), `procedural` (~1 month) — which sets how fast

--- a/sndr/cli/commands/__init__.py
+++ b/sndr/cli/commands/__init__.py
@@ -19,6 +19,7 @@ from sndr.cli.commands.mem import (
     MemImportCommand,
     MemNeighborsCommand,
     MemRecallCommand,
+    MemReflectCommand,
     MemRememberCommand,
     MemSearchCommand,
     MemStatsCommand,
@@ -96,6 +97,7 @@ def build_subparsers(subparsers: argparse._SubParsersAction) -> None:
     register(MemForgetCommand())
     register(MemImportCommand())
     register(MemExportCommand())
+    register(MemReflectCommand())
     # TUI cockpit (read-only Phase 1) — the command gates on the optional [tui]
     # extra (textual) with a friendly install hint when it's absent.
     register(TuiCommand())

--- a/sndr/cli/commands/mem.py
+++ b/sndr/cli/commands/mem.py
@@ -258,6 +258,29 @@ class MemImportCommand:
         return _run(args, _do)
 
 
+class MemReflectCommand:
+    name = "mem.reflect"
+    help = "Generative reflection: synthesize higher-level insight nodes from clusters."
+
+    def configure_parser(self, parser: argparse.ArgumentParser) -> None:
+        parser.add_argument("--min-cluster", type=int, default=3,
+                            help="min related memories to reflect on (default: 3)")
+        parser.add_argument("--max", type=int, default=5, dest="max_reflections",
+                            help="cap on new insight nodes (default: 5)")
+        _add_connection_args(parser)
+
+    def execute(self, args: argparse.Namespace) -> int:
+        def _do(client) -> int:
+            rep = client.reflect(owner_id=_owner(args), min_cluster=args.min_cluster,
+                                 max_reflections=args.max_reflections)
+            if getattr(args, "output", "text") == "json":
+                print(json.dumps(rep))
+            else:
+                print(f"reflected: {rep.get('reflections', 0)} new insight node(s)")
+            return 0
+        return _run(args, _do)
+
+
 class MemExportCommand:
     name = "mem.export"
     help = "Export memory back out as an Obsidian vault (notes + wikilinks)."
@@ -285,6 +308,7 @@ __all__ = [
     "MemImportCommand",
     "MemNeighborsCommand",
     "MemRecallCommand",
+    "MemReflectCommand",
     "MemRememberCommand",
     "MemSearchCommand",
     "MemStatsCommand",

--- a/sndr/memory/client.py
+++ b/sndr/memory/client.py
@@ -146,3 +146,14 @@ class MemoryHTTPClient:
         return self._call(
             "POST", "/api/v1/memory/export/obsidian", {"path": path}, owner=owner_id
         )
+
+    def reflect(
+        self, *, owner_id: int, min_cluster: int = 3, max_reflections: int = 5
+    ) -> dict[str, int]:
+        """Generative reflection: the daemon clusters memories and has the engine
+        synthesize higher-level insight nodes. Returns ``{reflections}``."""
+        return self._call(
+            "POST", "/api/v1/memory/reflect",
+            {"min_cluster": min_cluster, "max_reflections": max_reflections},
+            owner=owner_id,
+        )

--- a/sndr/memory/engine.py
+++ b/sndr/memory/engine.py
@@ -17,10 +17,28 @@ from typing import TYPE_CHECKING, Any
 from sndr.memory.model import SEMANTIC_EDGE_TAU, SearchHit
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from sndr.memory.embedder import Embedder
     from sndr.memory.store import MemoryStore
 
 _SIMILAR_REL = "similar_to"
+
+# Cap the observations quoted into a reflection prompt (context budget).
+_REFLECT_MAX_OBS = 20
+
+
+def _reflection_prompt(contents: list[str]) -> str:
+    """Build the Generative-Agents-style reflection prompt from a cluster of
+    observation texts."""
+    obs = "\n".join(f"- {c.strip()}" for c in contents[:_REFLECT_MAX_OBS] if c.strip())
+    return (
+        "You are the reflective memory of an assistant. Given these related "
+        "observations, state ONE concise higher-level insight they imply "
+        "(one sentence, no preamble). If they imply nothing, answer with an "
+        "empty line.\n\n"
+        f"Observations:\n{obs}\n\nInsight:"
+    )
 
 
 def run_maintenance(
@@ -196,6 +214,60 @@ class MemoryEngine:
             "communities": len(set(communities.values())),
             "nodes": len(communities),
         }
+
+    # ── reflection: the generative step (CREATES new knowledge) ─────────────
+    def reflect(
+        self,
+        *,
+        owner_id: int,
+        llm: Callable[[str], str],
+        min_cluster: int = 3,
+        max_reflections: int = 5,
+    ) -> dict[str, int]:
+        """Generative-Agents reflection: cluster related memories, ask the LLM
+        to synthesise a higher-level insight per cluster, and store each insight
+        as a NEW ``semantic`` node linked back to the observations it came from
+        (``derived_from`` edges). This is the only op that creates knowledge that
+        was not written verbatim; everything else only connects/ranks/decays.
+
+        ``llm`` is an injected ``(prompt) -> text`` callable so the engine stays
+        model-agnostic (the product wires it to the running vLLM engine). Derived
+        nodes are never fed back as source observations, so repeated passes do
+        not runaway into reflections-of-reflections. Returns ``{reflections: N}``.
+        """
+        communities = self.detect_communities(owner_id=owner_id)
+        by_comm: dict[int, list[int]] = {}
+        for nid, comm in communities.items():
+            by_comm.setdefault(comm, []).append(nid)
+
+        created = 0
+        for _comm, nids in sorted(by_comm.items()):
+            if created >= max_reflections:
+                break
+            nodes = [self.store.get_node(nid) for nid in nids]
+            # Only reflect over raw observations — skip prior insights.
+            observations = [
+                n for n in nodes if n and not n.properties.get("derived")
+            ]
+            if len(observations) < min_cluster:
+                continue
+            prompt = _reflection_prompt([n.content for n in observations])
+            insight = (llm(prompt) or "").strip()
+            if not insight:
+                continue
+            source_ids = [n.id for n in observations]
+            new_id = self.remember(
+                owner_id=owner_id,
+                text=insight,
+                kind="semantic",
+                importance=0.5,  # a derived insight is more salient than a raw turn
+                properties={"derived": True, "sources": source_ids},
+                dedup=False,
+            )
+            for sid in source_ids:
+                self.store.add_edge(new_id, sid, "derived_from", weight=1.0)
+            created += 1
+        return {"reflections": created}
 
     # ── graph view ───────────────────────────────────────────────────────
     def graph(

--- a/sndr/memory/llm.py
+++ b/sndr/memory/llm.py
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: Apache-2.0
+"""A tiny OpenAI-compatible completion helper for the memory engine's batch
+LLM steps (reflection, and later fact-extraction).
+
+Dependency-free (urllib, like `client.py`) so it works inside the daemon image
+without pulling httpx into the memory core. It turns the running vLLM engine
+(any OpenAI-compatible `/v1/chat/completions`) into the plain `(prompt) -> text`
+callable the engine's `reflect()` expects. The engine stays model-agnostic; this
+is the seam that binds it to whatever inference endpoint the daemon points at.
+"""
+from __future__ import annotations
+
+import json
+import urllib.request
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+def make_openai_llm(
+    base_url: str,
+    *,
+    api_key: str | None = None,
+    model: str = "local",
+    temperature: float = 0.3,
+    max_tokens: int = 256,
+    timeout: float = 60.0,
+) -> Callable[[str], str]:
+    """Build a ``(prompt) -> text`` callable that hits an OpenAI-compatible
+    ``/v1/chat/completions`` at ``base_url``. Non-2xx / malformed replies return
+    an empty string, so a reflection step degrades to "no insight" rather than
+    raising inside the batch."""
+    base = base_url.rstrip("/")
+    if not base.endswith("/v1"):
+        base = base + "/v1"
+
+    def _call(prompt: str) -> str:
+        body = json.dumps({
+            "model": model,
+            "messages": [{"role": "user", "content": prompt}],
+            "temperature": temperature,
+            "max_tokens": max_tokens,
+            "chat_template_kwargs": {"enable_thinking": False},
+        }).encode("utf-8")
+        headers = {"Content-Type": "application/json"}
+        if api_key:
+            headers["Authorization"] = f"Bearer {api_key}"
+        req = urllib.request.Request(  # noqa: S310 — base_url is operator-configured
+            f"{base}/chat/completions", data=body, headers=headers, method="POST"
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310
+                payload = json.loads(resp.read().decode("utf-8"))
+            return (payload["choices"][0]["message"]["content"] or "").strip()
+        except Exception:  # noqa: BLE001 — batch step: degrade to "no insight"
+            return ""
+
+    return _call

--- a/sndr/product_api/routes/memory.py
+++ b/sndr/product_api/routes/memory.py
@@ -44,6 +44,8 @@ from sndr.product_api.schemas.memory import (
     ObsidianImportIn,
     ObsidianImportOut,
     RecallIn,
+    ReflectIn,
+    ReflectOut,
     RememberIn,
     RememberOut,
     StatsOut,
@@ -259,6 +261,31 @@ def export_obsidian(
     vault = _confined_vault(body.path)  # export creates the dir; no is_dir gate
     report = export_vault(engine=eng, owner_id=owner_from_request(request), vault_path=str(vault))
     return Envelope(data=ObsidianExportOut(**report), meta=_meta())
+
+
+@router.post("/reflect", summary="Generative reflection: synthesize insight nodes from clusters")
+def reflect(body: ReflectIn, request: Request) -> Envelope[ReflectOut]:
+    from sndr.memory.llm import make_openai_llm
+
+    base = (
+        os.environ.get("SNDR_OPENAI_BASE_URL")
+        or os.environ.get("GATEWAY_UPSTREAM_URL", "")
+    ).strip()
+    if not base:
+        raise HTTPException(
+            status_code=503,
+            detail="reflection needs an engine endpoint (set SNDR_OPENAI_BASE_URL)",
+        )
+    key = os.environ.get("SNDR_ENGINE_API_KEY") or os.environ.get("GATEWAY_UPSTREAM_KEY")
+    model = os.environ.get("GENESIS_MEMORY_REFLECT_MODEL", "local")
+    eng = _engine(request)
+    report = eng.reflect(
+        owner_id=owner_from_request(request),
+        llm=make_openai_llm(base, api_key=key, model=model),
+        min_cluster=body.min_cluster,
+        max_reflections=body.max_reflections,
+    )
+    return Envelope(data=ReflectOut(**report), meta=_meta())
 
 
 __all__ = ["router"]

--- a/sndr/product_api/schemas/memory.py
+++ b/sndr/product_api/schemas/memory.py
@@ -74,6 +74,15 @@ class ObsidianExportOut(BaseModel):
     links: int
 
 
+class ReflectIn(BaseModel):
+    min_cluster: int = Field(default=3, ge=2, le=50, description="min cluster size to reflect on")
+    max_reflections: int = Field(default=5, ge=1, le=50, description="cap on new insight nodes")
+
+
+class ReflectOut(BaseModel):
+    reflections: int
+
+
 class HitOut(BaseModel):
     id: int
     content: str

--- a/tests/unit/test_memory_cli_verbs.py
+++ b/tests/unit/test_memory_cli_verbs.py
@@ -41,6 +41,8 @@ def _spy_client():
             return {"linked": 2, "communities": 1, "nodes": 5}
         if "neighbors" in path:
             return [{"id": 2, "rel": "similar_to", "weight": 0.9}]
+        if "reflect" in path:
+            return {"reflections": 2}
         if "export" in path:
             return {"notes": 5, "links": 6}
         if "import" in path:
@@ -89,6 +91,16 @@ def test_client_import_obsidian_posts_path():
     assert body == {"path": "MyVault"}
 
 
+def test_client_reflect_posts():
+    c, calls = _spy_client()
+    out = c.reflect(owner_id=1, min_cluster=3, max_reflections=4)
+    assert out["reflections"] == 2
+    method, path, body, _o = calls[0]
+    assert method == "POST"
+    assert path.endswith("/memory/reflect")
+    assert body == {"min_cluster": 3, "max_reflections": 4}
+
+
 def test_client_export_obsidian_posts_path():
     c, calls = _spy_client()
     out = c.export_obsidian(owner_id=1, path="OutVault")
@@ -102,7 +114,7 @@ def test_client_export_obsidian_posts_path():
 # ── CLI verbs registered + wired to the client ────────────────────────────────
 
 
-@pytest.mark.parametrize("verb", ["mem.consolidate", "mem.neighbors", "mem.forget", "mem.import", "mem.export"])
+@pytest.mark.parametrize("verb", ["mem.consolidate", "mem.neighbors", "mem.forget", "mem.import", "mem.export", "mem.reflect"])
 def test_verb_registered(verb):
     assert verb in COMMAND_REGISTRY
 
@@ -145,6 +157,10 @@ class _Fake:
         self.seen.append(("export_obsidian", k))
         return {"notes": 5, "links": 6}
 
+    def reflect(self, **k):
+        self.seen.append(("reflect", k))
+        return {"reflections": 2}
+
 
 def test_cli_consolidate_invokes_client():
     f = _Fake()
@@ -179,3 +195,10 @@ def test_cli_export_invokes_client():
     rc = _run_cli("mem.export", {"path": "OutVault"}, f)
     assert rc == 0
     assert f.seen[0][0] == "export_obsidian"
+
+
+def test_cli_reflect_invokes_client():
+    f = _Fake()
+    rc = _run_cli("mem.reflect", {"min_cluster": 3, "max_reflections": 5}, f)
+    assert rc == 0
+    assert f.seen[0][0] == "reflect"

--- a/tests/unit/test_memory_llm.py
+++ b/tests/unit/test_memory_llm.py
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: Apache-2.0
+"""The OpenAI-compatible completion seam for the memory engine's batch steps."""
+from __future__ import annotations
+
+import io
+import json
+
+from sndr.memory import llm as llm_mod
+
+
+class _Resp(io.BytesIO):
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+
+def _fake_urlopen(captured):
+    def _open(req, timeout=None):
+        captured["url"] = req.full_url
+        captured["headers"] = dict(req.headers)
+        captured["body"] = json.loads(req.data.decode("utf-8"))
+        return _Resp(json.dumps(
+            {"choices": [{"message": {"content": "an insight"}}]}
+        ).encode("utf-8"))
+    return _open
+
+
+def test_llm_posts_chat_completion(monkeypatch):
+    captured = {}
+    monkeypatch.setattr(llm_mod.urllib.request, "urlopen", _fake_urlopen(captured))
+    fn = llm_mod.make_openai_llm("http://engine:8000", api_key="k", model="qwen")
+    out = fn("say hi")
+    assert out == "an insight"
+    assert captured["url"] == "http://engine:8000/v1/chat/completions"
+    assert captured["body"]["model"] == "qwen"
+    assert captured["body"]["messages"][0]["content"] == "say hi"
+    # thinking disabled so the insight isn't a reasoning dump
+    assert captured["body"]["chat_template_kwargs"]["enable_thinking"] is False
+
+
+def test_llm_appends_v1_once(monkeypatch):
+    captured = {}
+    monkeypatch.setattr(llm_mod.urllib.request, "urlopen", _fake_urlopen(captured))
+    # base already ending in /v1 must not double it
+    fn = llm_mod.make_openai_llm("http://engine:8000/v1")
+    fn("x")
+    assert captured["url"] == "http://engine:8000/v1/chat/completions"
+
+
+def test_llm_degrades_to_empty_on_error(monkeypatch):
+    def _boom(req, timeout=None):
+        raise OSError("connection refused")
+    monkeypatch.setattr(llm_mod.urllib.request, "urlopen", _boom)
+    fn = llm_mod.make_openai_llm("http://engine:8000")
+    assert fn("x") == ""

--- a/tests/unit/test_memory_reflection.py
+++ b/tests/unit/test_memory_reflection.py
@@ -1,0 +1,116 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Reflection — the generative half of the brain.
+
+Every other mechanic (Hebbian, decay, spreading activation, communities) only
+connects, strengthens, or ranks memories that already exist. Reflection is the
+one step that CREATES new knowledge: it clusters related memories and asks an
+LLM to synthesise a higher-level insight, then stores that insight as a new
+`semantic` node linked back to the observations it was derived from — the
+Generative-Agents reflection tree.
+
+The LLM is an injected callable `(prompt: str) -> str`, so the whole thing is
+unit-tested deterministically with a fake — no engine, no network.
+"""
+from __future__ import annotations
+
+from sndr.memory.embedder import HashEmbedder
+from sndr.memory.engine import MemoryEngine
+from sndr.memory.inmemory import InMemoryStore
+
+
+def _engine() -> MemoryEngine:
+    return MemoryEngine(store=InMemoryStore(), embedder=HashEmbedder(dim=64))
+
+
+def _cluster(eng: MemoryEngine, owner: int, texts: list[str]) -> list[int]:
+    """A connected cluster (so community detection groups them together)."""
+    ids = [eng.remember(owner_id=owner, text=t, kind="episodic", dedup=False) for t in texts]
+    for a in ids:
+        for b in ids:
+            if a < b:
+                eng.store.add_edge(a, b, "similar_to", weight=1.0)
+    return ids
+
+
+def test_reflection_creates_a_new_derived_node():
+    eng = _engine()
+    before = _cluster(eng, 1, ["met Klaus at the library",
+                               "Klaus skipped lunch again",
+                               "Klaus stayed late reading"])
+    rep = eng.reflect(owner_id=1, llm=lambda _p: "Klaus has been unusually withdrawn.",
+                      min_cluster=3)
+    assert rep["reflections"] == 1
+    nodes = list(eng.store.iter_nodes(1))
+    # A brand-new node exists beyond the originals.
+    assert len(nodes) == len(before) + 1
+    insight = next(n for n in nodes if n.id not in before)
+    assert "withdrawn" in insight.content
+
+
+def test_reflection_node_is_semantic_and_marked_derived():
+    eng = _engine()
+    src = _cluster(eng, 1, ["a", "b", "c"])
+    eng.reflect(owner_id=1, llm=lambda _p: "an insight", min_cluster=3)
+    insight = next(n for n in eng.store.iter_nodes(1) if n.id not in src)
+    assert insight.kind == "semantic"
+    assert insight.properties.get("derived") is True
+    assert set(insight.properties.get("sources", [])) == set(src)
+
+
+def test_reflection_links_insight_to_its_sources():
+    eng = _engine()
+    src = _cluster(eng, 1, ["a", "b", "c"])
+    eng.reflect(owner_id=1, llm=lambda _p: "an insight", min_cluster=3)
+    insight = next(n for n in eng.store.iter_nodes(1) if n.id not in src)
+    neigh = {nid for nid, rel, _w in eng.store.neighbors(insight.id) if rel == "derived_from"}
+    assert neigh == set(src)
+
+
+def test_small_clusters_are_skipped():
+    eng = _engine()
+    _cluster(eng, 1, ["only", "two"])  # below min_cluster=3
+    rep = eng.reflect(owner_id=1, llm=lambda _p: "insight", min_cluster=3)
+    assert rep["reflections"] == 0
+
+
+def test_empty_llm_output_creates_nothing():
+    eng = _engine()
+    src = _cluster(eng, 1, ["a", "b", "c"])
+    rep = eng.reflect(owner_id=1, llm=lambda _p: "   ", min_cluster=3)
+    assert rep["reflections"] == 0
+    assert len(list(eng.store.iter_nodes(1))) == len(src)
+
+
+def test_max_reflections_caps_output():
+    eng = _engine()
+    _cluster(eng, 1, ["a1", "a2", "a3"])
+    _cluster(eng, 1, ["b1", "b2", "b3"])
+    _cluster(eng, 1, ["c1", "c2", "c3"])
+    rep = eng.reflect(owner_id=1, llm=lambda _p: "insight", min_cluster=3, max_reflections=2)
+    assert rep["reflections"] == 2
+
+
+def test_reflection_does_not_reflect_on_derived_nodes():
+    """A second reflection pass must not treat prior insights as raw observations
+    (no runaway reflection-of-reflections)."""
+    eng = _engine()
+    _cluster(eng, 1, ["a", "b", "c"])
+    eng.reflect(owner_id=1, llm=lambda _p: "insight-1", min_cluster=3)
+    calls = []
+
+    def spy_llm(prompt):
+        calls.append(prompt)
+        return "insight-2"
+
+    eng.reflect(owner_id=1, llm=spy_llm, min_cluster=3)
+    # The derived node must not have been fed back in as a source observation.
+    assert "insight-1" not in "".join(calls)
+
+
+def test_prompt_receives_the_cluster_contents():
+    eng = _engine()
+    _cluster(eng, 1, ["alpha fact", "beta fact", "gamma fact"])
+    seen = {}
+    eng.reflect(owner_id=1, llm=lambda p: seen.setdefault("p", p) or "x", min_cluster=3)
+    assert "alpha fact" in seen["p"]
+    assert "beta fact" in seen["p"]


### PR DESCRIPTION
## Why

Point 1 of the remaining memory-brain roadmap, and the heart of "memory that works like a brain". Every other mechanic only **connects/ranks/decays** existing memories. **Reflection is the one step that CREATES knowledge**: cluster related memories → LLM synthesizes a higher-level insight → store it as a new `semantic` node linked back to its source observations (`derived_from` edges) — the Generative-Agents reflection tree.

## What

- **`engine.reflect(owner_id, llm, …)`** — model-agnostic (`llm` is an injected `(prompt)->text`). Reflects only over raw observations (skips prior insights → no runaway), caps output, degrades to "no insight" on empty output.
- **`sndr/memory/llm.py` `make_openai_llm`** — dependency-free (urllib) OpenAI-compat `/v1/chat/completions` caller binding reflect() to the running vLLM engine (thinking off; non-2xx → "").
- **Reachable end-to-end:** `POST /api/v1/memory/reflect` (503 until `SNDR_OPENAI_BASE_URL` set) + `MemoryHTTPClient.reflect` + `sndr mem.reflect` (CLI_REFERENCE §7).

## TDD

`test_memory_reflection.py` (8): creates a derived node · marks it semantic+derived+sources · links to sources · skips small clusters · empty-output creates nothing · caps at max_reflections · **never reflects on derived nodes** · prompt carries the cluster contents. `test_memory_llm.py` (3): request construction, `/v1` idempotence, error→empty. Plus the reflect client+CLI verb tests.

## Verification
- 66 focused memory tests green; ruff-clean; audit_public_docs ✓ · security_scan ✓
- engine stays model-agnostic (the LLM is injected)

## Remaining roadmap
working-memory tier · Obsidian path-keyed dedup · typed entity/relation KG + LLM fact-extraction · GUI/TUI coherence.